### PR TITLE
Fix Ankaios naming typos

### DIFF
--- a/BB-SC/OSLayer/Virtualization/BB_Ankaios.md
+++ b/BB-SC/OSLayer/Virtualization/BB_Ankaios.md
@@ -1,5 +1,5 @@
 
-# Anaikos
+# Ankaios
 
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ BBs get collected in the [WorkInProgress folder](/WorkInProgress/). As soon as t
     - [OSLayer](/BB-SC/OSLayer/README.md)
         - Time
         - Virtualization
-            - [BB_Anaikos](/BB-SC/OSLayer/Virtualization/BB_Anaikos.md)
+            - [BB_Ankaios](/BB-SC/OSLayer/Virtualization/BB_Ankaios.md)
             - [BB_SR_VOSS](/BB-SC/OSLayer/Virtualization/BB_SR_VOSS.md)
 - [BB-SC-TC](/BB-SC-TC/README.md)
     - Testing

--- a/other/utils/structure.md
+++ b/other/utils/structure.md
@@ -66,7 +66,7 @@
     - [OSLayer](/BB-SC/OSLayer/README.md)
         - Time
         - Virtualization
-            - [BB_Anaikos](/BB-SC/OSLayer/Virtualization/BB_Anaikos.md)
+            - [BB_Ankaios](/BB-SC/OSLayer/Virtualization/BB_Ankaios.md)
             - [BB_SR_VOSS](/BB-SC/OSLayer/Virtualization/BB_SR_VOSS.md)
 - [BB-SC-TC](/BB-SC-TC/README.md)
     - Testing


### PR DESCRIPTION
This PR corrects naming typos for the Ankaios BB.

Please note that also the file BB_Anaikos.md was renamed to BB_Ankaios.md to correct the typo.