### PR TITLE
Bb common format

### DIFF
--- a/BB-EST/Build-and-Implementation/BB_VELOCITAS.md
+++ b/BB-EST/Build-and-Implementation/BB_VELOCITAS.md
@@ -1,4 +1,3 @@
-
 # VELOCITAS
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
@@ -10,6 +9,9 @@ Build and Implementation
 
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://github.com/eclipse-velocitas
@@ -71,8 +73,11 @@ Apache 2.0
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -100,7 +105,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -112,7 +116,6 @@ Example:
  Not supported anymore
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -125,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/BB-EST/Design/BB_SKyBT.md
+++ b/BB-EST/Design/BB_SKyBT.md
@@ -1,20 +1,17 @@
 # SKyBT 
-
 ## BB Tags(s)
-
 BB-EST, BB-CEST, BB-SC-TC, BB-CSC-TC
 
 ## Functional Clusters
-
 (Explanation: in which Functional Cluster the BB be located; if none of the existing fit new required)
 
-
 ## Layer
-
 MWLayer
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 Github repo: https://gitlab.eclipse.org/eclipse/skybt/skybt
 
 ## ID (unique name)
@@ -58,18 +55,18 @@ IAV
 <!-- High, Medium, Low -->
 
 ## Related Project(s)
-
 If Yes – e.g. The BB should be used/added in the Eclipse Blueprint A – for demo purposes, show added value, 
 If No – Project Proposal (e.g. WP4 in FEDERATE, or in the SDV EcoSystem Community Framework
 
-
 ## Availability of Source Code
-
 Yes / Apache License Version 2.0
 
 ## Availability of API
-
 Yes / Apache License Version 2.0
+
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
 ## Potential obstacles
 tbd
@@ -79,7 +76,6 @@ tbd
 
 ## State (+ date of last change)
 Used in production by 1 OEM
-
 
 ## System Context
 tbd
@@ -96,17 +92,6 @@ eg.
 - web assembly
 - web service
  -->
- 
- ## Bazel compliance status
- <!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->
 
-
-
-
-
-
-
-
-
-
-
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/BB-EST/Generator/BB_IFEX.md
+++ b/BB-EST/Generator/BB_IFEX.md
@@ -1,6 +1,4 @@
-
 # IFEX
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-EST
@@ -12,6 +10,9 @@ Generator
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
+
 ## Known Implementation
 https://github.com/COVESA/ifex
 
@@ -21,6 +22,7 @@ https://github.com/COVESA/ifex
 <!-- General Description of the BB -->
 IFEX is a general interface description and transformation technology which started in the Vehicle Service Catalog (VSC) project. 
 The project is a place to do difficult semantic mapping work. While doing so, it creates translating tools between formats and it results in a simple but powerful interface description format.
+
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
 
@@ -72,8 +74,11 @@ MPL 2.0
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -101,7 +106,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -113,7 +117,6 @@ Example:
  Implementation started
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -126,3 +129,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/BB-EST/Lifecycle-Management/BB_LEDA.md
+++ b/BB-EST/Lifecycle-Management/BB_LEDA.md
@@ -1,6 +1,4 @@
-
 # LEDA
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-EST
@@ -11,6 +9,9 @@ Lifecycle-Management
 
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://github.com/eclipse-leda
@@ -72,8 +73,11 @@ Apache 2.0
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -101,7 +105,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -113,7 +116,6 @@ Example:
  Incubating
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -126,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/BB-EST/Testing/BB_Autowrx.md
+++ b/BB-EST/Testing/BB_Autowrx.md
@@ -1,6 +1,4 @@
-
 # Autowrx
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-EST
@@ -11,6 +9,9 @@ Testing
 
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://gitlab.eclipse.org/eclipse/autowrx/autowrx
@@ -71,8 +72,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -100,7 +104,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -112,7 +115,6 @@ Example:
  Implementation started
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -125,3 +127,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/BB-EST/Testing/BB_Central_Data_Service_Playground.md
+++ b/BB-EST/Testing/BB_Central_Data_Service_Playground.md
@@ -1,6 +1,4 @@
-
 # Central Data Service Playground
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-EST
@@ -11,6 +9,9 @@ Testing
 
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://github.com/COVESA/cdsp
@@ -72,8 +73,11 @@ MPL 2.0
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -101,7 +105,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -113,7 +116,6 @@ Example:
 Implementation started
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -126,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/BB-EST/Testing/BB_OpenXilEnv.md
+++ b/BB-EST/Testing/BB_OpenXilEnv.md
@@ -1,6 +1,4 @@
-
 # OpenXilEnv
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-EST
@@ -12,6 +10,9 @@ Testing
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
+
 ## Known Implementation
 https://github.com/eclipse-openxilenv/openxilenv
 
@@ -21,7 +22,7 @@ https://github.com/eclipse-openxilenv/openxilenv
 <!-- General Description of the BB -->
 SW in the loop solution for virtual validation, similar to Synopsis Silver
 Simulate ECU functions, includes parameter management, Scripting interface. 
-With a Software In the Loop system it is possible to run and test embedded software without a target plattform and compiler. XilEnv is an environment to setup a SIL system on Windows or Linux host. 
+With a Software In the Loop system it is possible to run and test embedded software without a target plattform and compiler. XilEnv is an environment to setup a SIL system on Windows or Linux host.
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
@@ -74,8 +75,11 @@ Apache 2.0
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -103,7 +107,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -113,8 +116,8 @@ Example:
 - Abandoned
  -->
 Implementation started
-## System Context
 
+## System Context
 <!-- 
 OS and runtime/framework requirements
 
@@ -127,3 +130,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/BB-SC/1-HWLayer/HardwareAbstraction/Type-1-Hypervisor/XENProject/BB_XENHypervisor.md
+++ b/BB-SC/1-HWLayer/HardwareAbstraction/Type-1-Hypervisor/XENProject/BB_XENHypervisor.md
@@ -1,5 +1,4 @@
 # XENProject
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 
@@ -14,8 +13,10 @@ HardwareAbstraction; Virtualisation; Type-1-Hypervisor
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 HWLayer
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 https://github.com/xen-project/xen
 
 ## ID (unique name)
@@ -71,18 +72,16 @@ Evaluation availability and support for drivers used in the automotive domain - 
 Supported hardware (e.g. hhtps://hcl.xenserver.com/)
 Supported OS (Linux, Windows, MacOS, Zeyphr, ...)
 
-
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
 
 Safety (support for mixed criticality VMs on one host) 
 Security (support encryption, Identity and Access Managemnt)
-Real-Time (support firm and soft real-time) 
+Real-Time (support firm and soft real-time)
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 
@@ -92,7 +91,6 @@ If “Yes, proposal for additional Signals/Information – what should be made a
 Yes, information about platform utilisation, software versions, stored error, ... should be accessible at any time (also from outsiede) via a standardised API and a standardised data model/format.
 
 ## Author/Company
-
 Mario Driussi / VIF
 
 ## Priority
@@ -120,8 +118,11 @@ No - Commercial -->
 
 YES / LGPL-2.1 XENAPI
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -149,7 +150,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -163,7 +163,6 @@ Used in production by e.g. AWS Cloud Services
 last change 28.02.2025 (retrieved 03.03.2025)
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -179,5 +178,5 @@ eg.
 
 Type-1-Hypervisor
 
- ## Bazel compliance status
- <!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/BB-SC/2a-OSLayer/Virtualization/BB_Ankaios.md
+++ b/BB-SC/2a-OSLayer/Virtualization/BB_Ankaios.md
@@ -1,6 +1,4 @@
-
 # Ankaios
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Virtualization
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 OSLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://github.com/eclipse-ankaios/ankaios
@@ -73,8 +74,11 @@ Apache 2.0
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -102,7 +106,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -112,8 +115,8 @@ Example:
 - Abandoned
  -->
 Implementation started
-## System Context
 
+## System Context
 <!-- 
 OS and runtime/framework requirements
 
@@ -126,3 +129,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/BB-SC/2b-MWLayer/Communication/BB_KUKSA.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_KUKSA.md
@@ -1,6 +1,4 @@
-
 # KUKSA
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Communication
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://github.com/eclipse-kuksa
@@ -72,8 +73,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -101,7 +105,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -113,7 +116,6 @@ Example:
 Public releases available
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -126,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/BB-SC/2b-MWLayer/Communication/BB_VISSR.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_VISSR.md
@@ -1,6 +1,4 @@
-
 # VISSR
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Communication
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://github.com/COVESA/vissr
@@ -73,8 +74,11 @@ Mozilla Public License Version 2.0
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -102,7 +106,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -112,8 +115,8 @@ Example:
 - Abandoned
  -->
 Implementation started
-## System Context
 
+## System Context
 <!-- 
 OS and runtime/framework requirements
 
@@ -126,3 +129,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/BB-SC/2b-MWLayer/Communication/BB_eCAL.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_eCAL.md
@@ -1,6 +1,4 @@
-
 # eCAL
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Communication
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://github.com/eclipse-ecal/ecal
@@ -73,8 +74,11 @@ Apache 2.0
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -102,7 +106,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -114,7 +117,6 @@ Example:
  Implementation started
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -127,3 +129,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/BB-SC/2b-MWLayer/Communication/BB_uProtocol.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_uProtocol.md
@@ -1,6 +1,4 @@
-
 # uProtocol
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Communication
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://github.com/eclipse-uprotocol
@@ -73,8 +74,11 @@ Apache License, Version 2.0
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -102,7 +106,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -114,7 +117,6 @@ Example:
  Implementation started
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -127,3 +129,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/BB-SC/2b-MWLayer/Communication/BB_uServices.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_uServices.md
@@ -1,6 +1,4 @@
-
 # uServices
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Communication
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://github.com/COVESA/uservices
@@ -68,12 +69,16 @@ If No – Project Proposal (e.g. WP4 in FEDERATE, or in the SDV EcoSystem Commun
 <!-- Yes / License (e.g. Yes/MIT) 
 No – Commercial Closed Source -->
 Apache License Version 2.0
+
 ## Availability of API
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -101,7 +106,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -113,7 +117,6 @@ Example:
  Implementation started
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -126,3 +129,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/BB-SC/2b-MWLayer/Communication/RTPS-Types/FastDDS/BB_FastDDS.md
+++ b/BB-SC/2b-MWLayer/Communication/RTPS-Types/FastDDS/BB_FastDDS.md
@@ -1,27 +1,22 @@
-
 # Fast-DDS
-
 ## BB Tags(s)
-
 BB-SC; BB-MU; BB-CSC; BB-CMU
 
-
 ## Functional Clusters
-
 Communication
 
 ## Layer
-
 MWLayer
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 https://github.com/eProsima/Fast-DDS
 
 ## ID (unique name)
 
 ## Description
-
 eprosima Fast DDS is a C++ implementation of the DDS (Data Distribution Service) standard of the OMG (Object Management Group). eProsima Fast DDS implements the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP, as defined and maintained by the Object Management Group (OMG) consortium. RTPS is also the wire interoperability protocol defined for the Data Distribution Service (DDS) standard. eProsima Fast DDS expose an API to access directly the RTPS protocol, giving the user full access to the protocol internals.
 
 ## Rationale
@@ -29,26 +24,17 @@ eprosima Fast DDS is a C++ implementation of the DDS (Data Distribution Service)
 
 ## Governance Applicable S-BB(s)
 
-
-
 ## Compose BB(s)
-
 OS/Runtime Envirnoment
-
 
 ## What is needed to Design and Implement
 
-
-
 ## What is needed to build and run
-
 See [supported Platforms](https://github.com/eProsima/Fast-DDS/blob/master/PLATFORM_SUPPORT.md#platform-support)
 
-
 ## Non-Functional Requirements
-
 * Real Time
-* QOS 
+* QOS
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
@@ -60,24 +46,24 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 [eprosima](https://eprosima.com/)
 
 ## Priority
 <!-- High, Medium, Low -->
 
 ## Related Project(s)
-
 The most complete DDS - Proven: Plenty of success cases. Looking for commercial support? Contact info@eprosima.com 
 https://eprosima.com/
 
 ## Availability of Source Code
-
 YES/Apache 2.0
 
 ## Availability of API
+[Fast DDS CLI manual](https://fast-dds.docs.eprosima.com/en/latest/fastddscli/cli/cli.html)
 
-[Fast DDS CLI manual](https://fast-dds.docs.eprosima.com/en/latest/fastddscli/cli/cli.html) 
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
 ## Potential obstacles
 
@@ -110,10 +96,7 @@ Example:
 | --------- |:-------------:|:------------:|:-----------------:|:-------:|:---------------:|
 | Level     | [Gold](https://fast-dds.docs.eprosima.com/en/latest/) | Notdefined       | [Gold](https://github.com/eProsima/Fast-DDS/blob/master/CONTRIBUTING.md) | Notdefined | [Gold](https://github.com/eProsima/Fast-DDS/blob/master/RELEASE_SUPPORT.md) |
 
-
-
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -126,7 +109,6 @@ Used in several projects (e.g ROS2).
 last update Github Jan. 2025 / continuously updated
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -143,3 +125,5 @@ regarding details see section - What is needed to build and run
 
 Ubuntu/Debian, MacOS, Windows, Android, QNX
 
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/BB-SC/2b-MWLayer/Communication/RTPS-Types/OpenDDS/BB_OpenDDS.md
+++ b/BB-SC/2b-MWLayer/Communication/RTPS-Types/OpenDDS/BB_OpenDDS.md
@@ -1,34 +1,28 @@
-
 # OpenDDS
-
 ## BB Tags(s)
-
 BB-SC; BB-MU; BB-CSC; BB-CMU
 
-
 ## Functional Clusters
-
 Communication
 
 ## Layer
-
 MWLayer
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 https://github.com/OpenDDS/OpenDDS
 
 ## ID (unique name)
 
 ## Description
-
 OpenDDS is an open-source C++ implementation of the Object Management Group's specification "Data Distribution Service for Real-time Systems" (DDS), as well as some other related specifications. These standards define a set of interfaces and protocols for developing distributed applications based on the publish-subscribe and distributed cache models. Although OpenDDS is itself developed in C++, Java bindings are provided so that Java applications can use OpenDDS. OpenDDS also includes support for the DDS Security and XTypes specifications.
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
 
 ## Governance Applicable S-BB(s)
-
 This release of OpenDDS is based on the DDS Specification formal/2015-04-10 (version 1.4). It features the following transport protocols:
 
 *    TCP/IP
@@ -42,16 +36,12 @@ RTPS (Interoperability) features are based on the [DDS-RTPS Specification formal
 See the Developer's Guide for information on OpenDDS compliance with the DDS specification. If you would like to contribute a feature or sponsor the developers to add a feature please see the Support section above for contact information.
 
 ## Compose BB(s)
-
 OS/Runtime Envirnoment
 
-
 ## What is needed to Design and Implement
-
 These are just the required dependencies. For a complete detailed list of dependencies, including optional ones, see https://opendds.readthedocs.io/en/latest-release/devguide/building/dependencies.html.
 
 ## What is needed to build and run
-
 Operating Systems
 
 This release of OpenDDS has been tested under the following platforms:
@@ -101,11 +91,9 @@ This release of OpenDDS has been tested using the following compilers:
  Ubuntu clang 14.0.6
  Ubuntu clang 15.0.0
 
-
 ## Non-Functional Requirements
-
 Real Time
-QOS 
+QOS
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
@@ -117,24 +105,25 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Anonymous
 
 ## Priority
 <!-- High, Medium, Low -->
 
 ## Related Project(s)
-
 OpenDDS is an open source C++ implementation of the Object Management Group (OMG) Data Distribution Service (DDS). OpenDDS also supports Java bindings through JNI. 
 http://www.opendds.org/
 
 ## Availability of Source Code
-
 YES/OpenDDS (Licensed Product) is protected by copyright, and is distributed under the following terms.
 
 ## Availability of API
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
+
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
 ## Potential obstacles
 
@@ -169,7 +158,6 @@ Example:
 | Level		| [Gold](https://opendds.readthedocs.io/en/latest-release/)| Notdefined | [Gold](https://opendds.readthedocs.io/en/latest-release/devguide/index.html)	| Notdefined	| [Gold](https://opendds.readthedocs.io/en/latest-release/news.html) |
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -181,9 +169,7 @@ Example:
 Used in several projects
 Last Update Github Jan. 25 / continuously updated
 
-
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -200,3 +186,6 @@ eg.
 Regarding details see section - What is needed to build and run
 
 Ubuntu/Debian/Red Hat, openSUSE, Yocto, Windows, LynxOS, VxWorks, Android
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/BB-SC/2b-MWLayer/Communication/RTPS-Types/cycloneDDS/BB_cycloneDDS.md
+++ b/BB-SC/2b-MWLayer/Communication/RTPS-Types/cycloneDDS/BB_cycloneDDS.md
@@ -1,34 +1,28 @@
-
 # CycloneDDS
-
 ## BB Tags(s)
-
 BB-SC; BB-MU; BB-CSC; BB-CMU
 
-
 ## Functional Clusters
-
 Communication
 
 ## Layer
-
 MWLayer
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 https://github.com/eclipse-cyclonedds/cyclonedds
 
 ## ID (unique name)
 
 ## Description
-
 Eclipse Cyclone DDS is a very performant and robust open-source implementation of the OMG DDS specification. Cyclone DDS is developed completely in the open as an Eclipse IoT project (see eclipse-cyclone-dds) with a growing list of adopters (if you're one of them, please add your logo). It is a tier-1 middleware for the Robot Operating System ROS 2.
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
 
 ## Governance Applicable S-BB(s)
-
 Cyclone DDS aims at full coverage of the specs and today already covers most of this. With references to the individual OMG specifications, the following is available:
 
     [DCPS](https://www.omg.org/spec/DDS/1.4/PDF) the base specification 
@@ -43,15 +37,12 @@ Cyclone DDS aims at full coverage of the specs and today already covers most of 
     [DDSI-RTPS](https://www.omg.org/spec/DDSI-RTPS/2.5/PDF) - the interoperable network protocol
 
 ## Compose BB(s)
-
 OS/Runtime Envirnoment
-
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
 
 ## What is needed to build and run
-
 In order to build Cyclone DDS you need a Linux, Mac or Windows 10 machine (or, with some caveats, a *BSD, QNX, OpenIndiana or a Solaris 2.6 one) with the following installed on your host:
 
 C compiler (most commonly GCC on Linux, Visual Studio on Windows, Xcode on macOS);
@@ -61,11 +52,9 @@ Optionally OpenSSL, we recommend a fully patched and supported version but 1.1.1
 Optionally Eclipse Iceoryx version 2.0 for shared memory and zero-copy support;
 Optionally Bison parser generator. A cached source is checked into the repository.
 
-
 ## Non-Functional Requirements
-
 Real Time
-QOS 
+QOS
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
@@ -77,28 +66,28 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Anonymous
 
 ## Priority
 <!-- High, Medium, Low -->
 
 ## Related Project(s)
-
 https://projects.eclipse.org/projects/iot.cyclonedds
 
 ## Availability of Source Code
-
 YES/Eclipse Public License - v 2.0
 
 ## Availability of API
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
+
 ## Potential obstacles
 
 ## Maturity Badges
-
 <!-- taken over from Eclipse SDV Process 
 See Definition of Badges and their Flavors 
 https://gitlab.eclipse.org/eclipse-wg/sdv-wg/sdv-technical-alignment/sdv-technical-topics/sdv-process/sdv-process-definition/-/wikis/Definition%20of%20Badges%20and%20their%20Flavors 
@@ -127,7 +116,6 @@ Example:
 | Level     | [Gold](https://cyclonedds.io/docs/) | Notdefined       | Notdefined | Notdefined | [Gold](https://cyclonedds.io/docs/) |
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -141,7 +129,6 @@ Used in several projects (e.g ROS2).
 Last update Github Jan. 2025 / continuously updated
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -156,3 +143,6 @@ eg.
  -->
 
 regarding details see section - What is needed to build and run
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/BB-SC/2b-MWLayer/Communication/RTPS-Types/embeddedRTPS/BB_Constraint_DDS_embeddedRTPS.md
+++ b/BB-SC/2b-MWLayer/Communication/RTPS-Types/embeddedRTPS/BB_Constraint_DDS_embeddedRTPS.md
@@ -1,96 +1,79 @@
 # embeddedRTPS - DDS for Ressource-constrained environments
-
 ## BB Tags(s)
-
 BB-SC, BB-CSC, BB-MU, BB-CMU
 
 ## Functional Clusters
-
 Communication
 
 ## Layer
-
 MWLayer
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 Github repo: <https://github.com/embedded-software-laboratory/embeddedRTPS>
 
 ## ID (unique name)
 
 ## Description
-
 This repository contains source code for embeddedRTPS, a portable and open-source C++ implementation of the Real-Time Publish-Subscribe Protocol (RTPS) for embedded system. RTPS is based on the publish-subscribe mechanism and is at the core of the Data Distribution Service (DDS). DDS is used, among many other applications, in Robot Operating System 2 (ROS2) and is also part of the AUTOSAR Adaptive platform. embeddedRTPS allows to integrate Ethernet-capable microcontrollers into DDS-based systems as first-class participants.
 embeddedRTPS is portable, as it only consumes lightweightIP and FreeRTOS APIs, which are available for a large number of embedded systems. embeddedRTPS avoids dynamic memory allocation once endpoints are constructed possible. Please note that embeddedRTPS only implements rudimentary Quality-of-Service (QoS) policies and is far from a complete RTPS implementation.
-
 
 ## Rationale
 This light-weight DDS stack allows to integrate ressource constraint devices into SOA architectures. DDS is used as a middleware in AUTOSAR Adaptive and ROS 2.
 
 ## Governance Applicable S-BB(s)
-
 https://www.omg.org/spec/DDS/ (deviations from spec.)
 https://www.omg.org/spec/DDSI-RTPS/ (implemented partially) 
 https://www.omg.org/spec/DDS-SECURITY/ (not implemented in pub version)
 
-
 ## Compose BB(s)
-
 FreeRTOS or other OS/Runtime Envirnoment
 lwIP (could be another NW Stack)
 
-
 ## What is needed to Design and Implement
-
 The Repo include a reference implementation which is executable on different Targets /STM32, AURIX Tricore.
 Needed:
 MW Layer to use it with ROS2 (RMW) or adaptive AUTOSAR (commonAPI support).
 Support for Security concepts in the OSS implementation. (see Applicable S-BB(s))
 
 ## What is needed to build and run
- 
 See: Example with a getting started for STM32 (Linux/Mac)
 GCC (Ubuntu 18 and above), Tasking Compiler,  
 <https://github.com/embedded-software-laboratory/embeddedRTPS-STM32>
 
-
 ## Non-Functional Requirements
-
 Real-Time
 Security
 
 ## Dependencies to other Clusters
 
-
 ## Vehicle API Relevant
-
 “No”
 
 ## Author/Company
-
 Alexandru Kampmann RWTH
 
 ## Priority
 <!-- High, Medium, Low -->
 
 ## Related Project(s)
-
 <https://github.com/mROS-base/mros2>
 <https://github.com/micro-ROS>
 
 ## Availability of Source Code
-
 Yes / License MIT
 Commercial Closed Source Parts are available (security)
 
 ## Availability of API
-
 Yes / License MIT
 
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
+
 ## Potential obstacles
-
-
-
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -122,7 +105,6 @@ Example:
 | Level		| Notdefined | Notdefined   | Notdefined   | Notdefined	 | Notdefined |
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -132,10 +114,9 @@ Example:
 - Abandoned
  -->
 First public release available, used in [unicaragil](https://www.unicaragil.de/en/)
-last update Github Jul 2024 
+last update Github Jul 2024
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -151,3 +132,5 @@ eg.
 
 regarding details see section - What is needed to build and run
 
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/BB-SC/2b-MWLayer/Communication/RTPS-Types/vSomeIP/BB_vSomeIP.md
+++ b/BB-SC/2b-MWLayer/Communication/RTPS-Types/vSomeIP/BB_vSomeIP.md
@@ -1,6 +1,4 @@
-
 # vSOME/IP
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC; BB-MU; BB-CSC; BB-CMU
@@ -15,8 +13,10 @@ Communication
 
 MWLayer
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 [vSomeIP](https://github.com/COVESA/vsomeip)
 
 ## ID (unique name)
@@ -26,7 +26,6 @@ MWLayer
 
 SOME/IP is an abbreviation for "Scalable service-Oriented middlewarE over IP". This middleware was designed for typical automotive use cases and for being compatible with AUTOSAR (at least on the wire-format level). A publicly accessible specification is available [at](http://some-ip.com/). In this wiki we do not want to deepen further into the reasons for another middleware specification, but want to give a rough overview about the basic structures of the SOME/IP specification and its open source implementation vsomeip without any claim of completeness.
 [source](https://github.com/COVESA/vsomeip/wiki/vsomeip-in-10-minutes)
-
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
@@ -47,7 +46,6 @@ Reference to e.g. IS026262, AUTOSAR Spec. X -->
  ISO 17215:2-2014
  Genivi/COVESA vsomeip
 
-
 ## Compose BB(s)
 <!-- Link to required BB(s) -->
 
@@ -57,7 +55,7 @@ Reference to e.g. IS026262, AUTOSAR Spec. X -->
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
 
-[see COVESA Github repo](https://github.com/COVESA/vsomeip) 
+[see COVESA Github repo](https://github.com/COVESA/vsomeip)
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
@@ -71,9 +69,7 @@ e.g. If FC Security : Security BBs are needed but you can choose for example cry
 If “No” – nothing more to do 
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
-
 ## Author/Company
-
 Anonymous
 
 ## Priority
@@ -90,10 +86,12 @@ Yes / vSomeIP - Mozilla Public License Version 2.0
 No – Commercial Closed Source -->
 
 ## Availability of API
-
-
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
+
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
 ## Potential obstacles
 
@@ -126,7 +124,6 @@ Example:
 | Level     | [Silver](https://github.com/COVESA/vsomeip/wiki) | [Gold](https://github.com/COVESA/vsomeip/tree/master/test)       | [Gold](https://github.com/COVESA/vsomeip/wiki/vsomeip-Contribution-Process) | Notdefined | [Gold](https://github.com/COVESA/vsomeip/wiki/vsomeip-Release-Process) |
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -139,9 +136,7 @@ Example:
 Used in several projects, proprietary implementations available
 Last update Github Jan. 2025 / continuously updated
 
-
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -156,3 +151,6 @@ eg.
  -->
  
  Linux
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/S-BB/2b-MWLayer/BB_Common_Vehicle_Capabilities.md
+++ b/S-BB/2b-MWLayer/BB_Common_Vehicle_Capabilities.md
@@ -1,6 +1,4 @@
-
 # VSS
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -11,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://covesa.global/project/common-vehicle-capabilities/
@@ -71,8 +72,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -100,7 +104,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -112,7 +115,6 @@ Example:
  Incubating
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -125,3 +127,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/S-BB/2b-MWLayer/BB_Data_Architecture_Terminology.md
+++ b/S-BB/2b-MWLayer/BB_Data_Architecture_Terminology.md
@@ -1,6 +1,4 @@
-
 # Data Architecture Terminology
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -11,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://covesa.global/project/data-architecture-terminology/
@@ -71,8 +72,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -100,7 +104,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -110,8 +113,8 @@ Example:
 - Abandoned
  -->
 Incubating
-## System Context
 
+## System Context
 <!-- 
 OS and runtime/framework requirements
 
@@ -124,3 +127,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/S-BB/2b-MWLayer/BB_EV_Charging_Event_Data_Aggregation.md
+++ b/S-BB/2b-MWLayer/BB_EV_Charging_Event_Data_Aggregation.md
@@ -1,6 +1,4 @@
-
 # EV Charging Event Data Aggregation
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -11,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://covesa.global/project/ev-charging-event-data-aggregation/
@@ -71,8 +72,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -100,7 +104,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -110,8 +113,8 @@ Example:
 - Abandoned
  -->
 Incubating
-## System Context
 
+## System Context
 <!-- 
 OS and runtime/framework requirements
 
@@ -124,3 +127,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/S-BB/2b-MWLayer/BB_HIM.md
+++ b/S-BB/2b-MWLayer/BB_HIM.md
@@ -1,6 +1,4 @@
-
 # HIM
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -11,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://github.com/COVESA/hierarchical_information_model
@@ -72,8 +73,11 @@ MPL 2.0
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -101,7 +105,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -113,7 +116,6 @@ Example:
  Incubating
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -126,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/S-BB/2b-MWLayer/BB_In_Car_Wallet_Payments_and_Orchestration.md
+++ b/S-BB/2b-MWLayer/BB_In_Car_Wallet_Payments_and_Orchestration.md
@@ -1,4 +1,3 @@
-
 # InCar Wallet Payments and Orchestration
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
@@ -10,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://covesa.global/project/in-car-wallet-payments-orchestration/
@@ -70,8 +72,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -99,7 +104,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -109,8 +113,8 @@ Example:
 - Abandoned
  -->
 Incubating
-## System Context
 
+## System Context
 <!-- 
 OS and runtime/framework requirements
 
@@ -123,3 +127,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/S-BB/2b-MWLayer/BB_Private_Cross_OEM_Joint_Compute_for_EV_Charging.md
+++ b/S-BB/2b-MWLayer/BB_Private_Cross_OEM_Joint_Compute_for_EV_Charging.md
@@ -1,4 +1,3 @@
-
 # Private Cross OEM Joint Compute for EV Charging
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
@@ -10,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://covesa.global/project/private-cross-oem-joint-compute-for-ev-charging/
@@ -70,8 +72,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -99,7 +104,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -109,8 +113,8 @@ Example:
 - Abandoned
  -->
 Incubating
-## System Context
 
+## System Context
 <!-- 
 OS and runtime/framework requirements
 
@@ -123,3 +127,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/S-BB/2b-MWLayer/BB_Unified_Push_Notification.md
+++ b/S-BB/2b-MWLayer/BB_Unified_Push_Notification.md
@@ -1,6 +1,4 @@
-
 # Unified Push Notification
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -11,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://covesa.global/project/unified-push-notifications/
@@ -71,8 +72,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -100,7 +104,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -110,8 +113,8 @@ Example:
 - Abandoned
  -->
 Incubating
-## System Context
 
+## System Context
 <!-- 
 OS and runtime/framework requirements
 
@@ -124,3 +127,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/S-BB/2b-MWLayer/BB_VSS.md
+++ b/S-BB/2b-MWLayer/BB_VSS.md
@@ -1,6 +1,4 @@
-
 # VSS
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -11,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://github.com/covesa/vehicle_signal_specification
@@ -72,8 +73,11 @@ MPL 2.0
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -101,7 +105,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -113,7 +116,6 @@ Example:
 Implementation started
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -126,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/S-BB/2b-MWLayer/Communication/BB_VISS.md
+++ b/S-BB/2b-MWLayer/Communication/BB_VISS.md
@@ -1,6 +1,4 @@
-
 # VISS
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -12,6 +10,9 @@ Communication
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://github.com/COVESA/vehicle-information-service-specification
@@ -73,8 +74,11 @@ Mozilla Public License, v. 2.0
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -102,7 +106,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -112,8 +115,8 @@ Example:
 - Abandoned
  -->
 Implementation started
-## System Context
 
+## System Context
 <!-- 
 OS and runtime/framework requirements
 
@@ -126,3 +129,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/S-BB/Generator/BB_Commercial_Vehicle_Information_Specifications.md
+++ b/S-BB/Generator/BB_Commercial_Vehicle_Information_Specifications.md
@@ -1,6 +1,4 @@
-
 # Commercial Vehicle Information Specifications
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -11,6 +9,9 @@ Generator
 
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 https://github.com/COVESA/commercial-vehicle-information-specifications
@@ -72,8 +73,11 @@ MPL 2.0
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -101,7 +105,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -111,8 +114,8 @@ Example:
 - Abandoned
  -->
 Implementation started
-## System Context
 
+## System Context
 <!-- 
 OS and runtime/framework requirements
 
@@ -125,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-CEST/BB_Car_Simulator.md
+++ b/WorkInProgress/BB-CEST/BB_Car_Simulator.md
@@ -1,6 +1,4 @@
-
 # Car Simulator
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-CEST
@@ -13,8 +11,10 @@ Not Specified
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 Not Specified
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 Eclipse SDV - kanto.auto (old) will be published under a new name
 Eclipse OpenDUT
 [Carla](https://carla.org/)
@@ -67,7 +67,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Anonymous
 
 ## Priority
@@ -85,8 +84,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -114,7 +116,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -125,7 +126,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -138,3 +138,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-CEST/Diagnostics/BB_RemotiveCloud.md
+++ b/WorkInProgress/BB-CEST/Diagnostics/BB_RemotiveCloud.md
@@ -1,6 +1,4 @@
-
 # RemotiveCloud
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-CEST; BB-CSC-TC
@@ -13,8 +11,11 @@ Diagnostics (could also be used for feeding vehicle data to emulators and other 
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 Not Specified
 
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
+
 ## Known Implementation
-https://cloud.remotivelabs.com/ 
+https://cloud.remotivelabs.com/
 
 ## ID (unique name)
 
@@ -25,7 +26,6 @@ RemotiveCloud - for sharing vehicle recordings, both for debugging purposes as w
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
 RemotiveCloud enables an easy way of sharing recordings - upload to cloud and share with relevant people as suppliers and service providers to have a common place for vehicle network data (CAN etc.) for debugging and 3rd party application developers.
-
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system
@@ -41,7 +41,7 @@ None
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
-Nothing, create an account and get going (there is a free tier available). 
+Nothing, create an account and get going (there is a free tier available).
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
@@ -72,21 +72,23 @@ Emil Dautovic / RemotiveLabs
 <!-- If Yes – e.g. The BB should be used/added in the Eclipse Blueprint A – for demo purposes, show added value,
 If No – Project Proposal (e.g. WP4 in FEDERATE, or in the SDV EcoSystem Community Framework -->
 Yes, part of Playground under the COVESA umbrella. 
-No active role in FEDERATE yet but there should be a good fit under WP2 projects where there is a need to collaborate in an easy way when it comes to vehicle data (from a test rig or an actual vehicle) for both debugging as well as prototyping purposes (either OEM propritary format or COVESA VSS). 
+No active role in FEDERATE yet but there should be a good fit under WP2 projects where there is a need to collaborate in an easy way when it comes to vehicle data (from a test rig or an actual vehicle) for both debugging as well as prototyping purposes (either OEM propritary format or COVESA VSS).
 
 ## Availability of Source Code
 <!-- Yes / License (e.g. Yes/MIT) 
 No – Commercial Closed Source -->
-The core RemotiveLabs components are Commercial Closed Source but reference integrations are available as source code https://github.com/remotivelabs 
-
+The core RemotiveLabs components are Commercial Closed Source but reference integrations are available as source code https://github.com/remotivelabs
 
 ## Availability of API
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
-https://docs.remotivelabs.com/docs/category/remotivecloud 
+https://docs.remotivelabs.com/docs/category/remotivecloud
+
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
 ## Potential obstacles
-
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -114,7 +116,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -125,7 +126,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -138,3 +138,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-CMU/BB_Digital_Twin_proxy_in_cloud.md
+++ b/WorkInProgress/BB-CMU/BB_Digital_Twin_proxy_in_cloud.md
@@ -1,6 +1,4 @@
-
 # Digital Twin proxy in cloud
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-CMU
@@ -13,8 +11,10 @@ Not specified
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 Not specified
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 Eclipse Ditto
 
 ## ID (unique name)
@@ -75,7 +75,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -94,8 +93,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -123,7 +125,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -134,7 +135,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -147,3 +147,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-CSC/BB_Active_diagnostics_and_repair_services.md
+++ b/WorkInProgress/BB-CSC/BB_Active_diagnostics_and_repair_services.md
@@ -1,6 +1,4 @@
-
 # Active diagnostics and repair services
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-CSC
@@ -12,6 +10,9 @@ Not specified
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 Not specified
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -68,8 +69,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -97,7 +101,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -108,7 +111,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -121,3 +123,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-CSC/BB_App_and_services_store.md
+++ b/WorkInProgress/BB-CSC/BB_App_and_services_store.md
@@ -1,6 +1,4 @@
-
 # App/Services store
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-CSC
@@ -12,6 +10,9 @@ Not specified
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 Not specified
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -69,8 +70,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -98,7 +102,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -109,7 +112,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -122,3 +124,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-CSC/BB_Cloud_container_and_OS.md
+++ b/WorkInProgress/BB-CSC/BB_Cloud_container_and_OS.md
@@ -1,5 +1,4 @@
 # Cloud contaier and OS
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-CSC
@@ -12,8 +11,10 @@ Not specified
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 Not specified
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 Blackberry QNX
 OxidOS
 Eclipse ThreadX
@@ -73,8 +74,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -102,7 +106,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -113,7 +116,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -126,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-CSC/BB_Config_and_settngs_collector.md
+++ b/WorkInProgress/BB-CSC/BB_Config_and_settngs_collector.md
@@ -1,6 +1,4 @@
-
 # Config and settings collector
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-CSC
@@ -12,6 +10,9 @@ Not specified
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 Not specified
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -69,8 +70,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -98,7 +102,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -109,7 +112,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -122,3 +124,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-CSC/BB_Data_manager_ensuring_compliance_with_regulation.md
+++ b/WorkInProgress/BB-CSC/BB_Data_manager_ensuring_compliance_with_regulation.md
@@ -1,6 +1,4 @@
-
 # Data manager ensuring compliance with regulation
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-CSC
@@ -12,6 +10,9 @@ Not specified
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 Not specified
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -69,8 +70,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -98,7 +102,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -109,7 +112,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -122,3 +124,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-CSC/BB_Data_spaces.md
+++ b/WorkInProgress/BB-CSC/BB_Data_spaces.md
@@ -1,6 +1,4 @@
-
 # Data Spaces
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-CSC
@@ -12,6 +10,9 @@ Not specified
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 Not specified
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 Catena-X
@@ -70,8 +71,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -99,7 +103,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -110,7 +113,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -123,3 +125,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-CSC/BB_Driver_authentication.md
+++ b/WorkInProgress/BB-CSC/BB_Driver_authentication.md
@@ -1,6 +1,4 @@
-
 # Driver authentication
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-CSC
@@ -12,6 +10,9 @@ Not specified
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 Not specified
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -69,8 +70,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -98,7 +102,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -109,7 +112,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -122,3 +124,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-CSC/BB_Driver_monitor.md
+++ b/WorkInProgress/BB-CSC/BB_Driver_monitor.md
@@ -1,6 +1,4 @@
-
 # Driver Monitor
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-CSC
@@ -12,6 +10,9 @@ Not specified
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 Not specified
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -69,8 +70,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -98,7 +102,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -109,7 +112,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -122,3 +124,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-CSC/BB_End_to_end_security_for_C2X.md
+++ b/WorkInProgress/BB-CSC/BB_End_to_end_security_for_C2X.md
@@ -1,6 +1,4 @@
-
 # End-to-end security for C2X
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-CSC
@@ -12,6 +10,9 @@ Not specified
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 Not specified
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -69,8 +70,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -98,7 +102,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -109,7 +112,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -122,3 +124,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-CSC/BB_Extended_accident_data_recorder.md
+++ b/WorkInProgress/BB-CSC/BB_Extended_accident_data_recorder.md
@@ -1,6 +1,4 @@
-
 # Extended accident data recorder
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-CSC
@@ -12,6 +10,9 @@ Not specified
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 Not specified
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -69,8 +70,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -98,7 +102,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -109,7 +112,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -122,3 +124,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-CSC/BB_Monitoring_and_Tracing_of_specific_HW_in_vehicle.md
+++ b/WorkInProgress/BB-CSC/BB_Monitoring_and_Tracing_of_specific_HW_in_vehicle.md
@@ -1,6 +1,4 @@
-
 # Monitoring and tracing specific HW in vehicle
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-CSC
@@ -12,6 +10,9 @@ Not specified
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 Not specified
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -69,8 +70,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -98,7 +102,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -109,7 +112,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -122,3 +124,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-CSC/BB_Orchestration_support_for_energy_and_mobility_providers.md
+++ b/WorkInProgress/BB-CSC/BB_Orchestration_support_for_energy_and_mobility_providers.md
@@ -1,6 +1,4 @@
-
 # Orchestration support for energy and mobility providers
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-CSC
@@ -13,13 +11,15 @@ Not specified
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 Not specified
 
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
+
 ## Known Implementation
 
 ## ID (unique name)
 
 ## Description
 <!-- General Description of the BB -->
-
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
@@ -69,8 +69,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -98,7 +101,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -109,7 +111,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -122,3 +123,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-CSC/BB_Secure_and_privacy_aware_voice_assistant.md
+++ b/WorkInProgress/BB-CSC/BB_Secure_and_privacy_aware_voice_assistant.md
@@ -1,6 +1,4 @@
-
 # Secure and privacy aware voice assistant
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-CSC
@@ -12,6 +10,9 @@ Not specified
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 Not specified
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -69,8 +70,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -98,7 +102,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -109,7 +112,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -122,3 +124,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-CSC/BB_Vehicle_data_streaming.md
+++ b/WorkInProgress/BB-CSC/BB_Vehicle_data_streaming.md
@@ -1,6 +1,4 @@
-
 # Vehicle data streaming
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-CSC
@@ -12,6 +10,9 @@ Not specified
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 Not specified
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -69,8 +70,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -98,7 +102,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -109,7 +112,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -122,3 +124,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-CSC/BB_Vehicle_monitor.md
+++ b/WorkInProgress/BB-CSC/BB_Vehicle_monitor.md
@@ -1,6 +1,4 @@
-
 # Vehicle monitor
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-CSC
@@ -12,6 +10,9 @@ Not specified
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 Not specified
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -69,8 +70,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -98,7 +102,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -109,7 +112,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -122,3 +124,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-EST/Configuration-and-Calibration/BB_Offboard_Config_Tool_for_TSN.md
+++ b/WorkInProgress/BB-EST/Configuration-and-Calibration/BB_Offboard_Config_Tool_for_TSN.md
@@ -1,6 +1,4 @@
-
 # Offboard Config Tool for TSN
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-EST
@@ -11,6 +9,9 @@ Configuration-and-Calibration
 
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -70,8 +71,11 @@ No – Commercial Closed Source -->
 No - Commercial -->
 Commercial
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -99,7 +103,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -111,7 +114,6 @@ Example:
  Incubating
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -124,3 +126,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-EST/Requirements/BB_DocAsCode.md
+++ b/WorkInProgress/BB-EST/Requirements/BB_DocAsCode.md
@@ -1,6 +1,4 @@
-
 # DocAsCode
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-EST
@@ -13,8 +11,10 @@ Requirements
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 None
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 [Open Fast Trace](https://github.com/itsallcode/openfasttrace)
 
 ## ID (unique name)
@@ -22,7 +22,6 @@ None
 ## Description
 <!-- General Description of the BB -->
 This BB aims to track and manage the software requirements of the different variants of the source code.
-
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
@@ -36,7 +35,6 @@ In contrast to other industries, the automotive market with high international c
 If the source code of the systems is maintained in variants (branches) and developed by means of CI/CD (Continuous Integration & Development) up to the control unit, the software requirements must also be manageable and versionable, just like the source code. This then allows the transfer of customized requirements from one branch to another (merge), the comparison of requirements (diff) and the automated check that all requirements along the necessary V-model artifacts (architecture, design, code, tests, test results) are covered (tracing).
 
 To this end, we as OEMs see it as essential to use these so-called "DocAsCode" approaches more efficiently directly in the development of ECU software internally as well as along the supply chain. Of course, this does not exempt us from overall systems engineering and model-based development, in any case we consider basic research to be less relevant there.
-
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system
@@ -67,7 +65,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Tom Fleischmann
 
 ## Priority
@@ -85,6 +82,10 @@ No – Commercial Closed Source -->
 ## Availability of API
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
+
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
 ## Potential obstacles
 
@@ -113,9 +114,7 @@ Example:
 
 -->
 
-
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -126,7 +125,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -139,3 +137,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-EST/Testing/BB_OpenDUT.md
+++ b/WorkInProgress/BB-EST/Testing/BB_OpenDUT.md
@@ -1,31 +1,25 @@
 # OpenDUT 
-
 ## BB Tags(s)
-
 BB-EST, BB-CEST, BB-SC-TC, BB-CSC-TC
 
 ## Functional Clusters
-
 (Explanation: in which Functional Cluster the BB be located; if none of the existing fit new required)
 
-
 ## Layer
-
 MWLayer
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 Github repo: https://github.com/eclipse-opendut/opendut
 
 ## ID (unique name)
 
 ## Description
-
 Eclipse openDuT provides an open framework to automate the testing and validation process for automotive software and applications in a reliable, repeatable and observable way. Eclipse openDuT is hardware-agnostic with respect to the execution environment and accompanies different hardware interfaces and standards regarding the usability of the framework. Thereby, it is supporting both on-premise installations and hosting in a cloud infrastructure. Eclipse openDuT considers an eventually distributed network of real (HIL) and virtual devices (SIL) under test. Eclipse openDuT reflects hardware capabilities and constraints along with the chosen test method. Test cases are not limited to a specific domain, but it especially realizes functional and explorative security tests.
 
-
 ## Rationale
-
 Main Use Case are:
 (Fully automated) grey-box tests for single ECUs or clusters of ECUs
 Execution of tests over distributed test benches
@@ -36,25 +30,16 @@ Observation of the test setup to verify if the test has been effective.
 Cloud/on-premises/hybrid deployments
 Adaption and full functional integration of 3rd party components (OSS, proprietary/ private source)
 
-
-
 ## Governance Applicable S-BB(s)
-
 Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system 
 Reference to defined S-BB(s) 
 Reference to e.g. IS026262, AUTOSAR Spec. X
 
-
-
 ## Compose BB(s)
-
 E.g. BB-SC StateManagement
 BB is a composition of other BBs
 
-
-
 ## What is needed to Design and Implement
-
 We expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language 
 
 Linux development environment, 
@@ -63,26 +48,18 @@ Server: x86_64
 Programming language: Rust
 Test environment: THEO
 
-
 ## What is needed to build and run
- 
 NetBird, Wireguard, TURN Sever, Keycloak, Linux-based OS, Cannelloni for CAN support, telemetry stack (Promtail, Loki, Prometheus, Tempo, Grafana), …
 
-
 ## Non-Functional Requirements
-
 With respect to Safety, Security,
 Encrypted connections between clients, server and peers
 
-
 ## Dependencies to other Clusters
-
 Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are  needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work
 
-
 ## Vehicle API Relevant
-
 “No”
 
 ## Author/Company
@@ -92,18 +69,18 @@ Anonymous
 <!-- High, Medium, Low -->
 
 ## Related Project(s)
-
 If Yes – e.g. The BB should be used/added in the Eclipse Blueprint A – for demo purposes, show added value, 
 If No – Project Proposal (e.g. WP4 in FEDERATE, or in the SDV EcoSystem Community Framework
 
-
 ## Availability of Source Code
-
 Yes / Apache License Version 2.0
 
 ## Availability of API
-
 Yes / Apache License Version 2.0
+
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
 ## Potential obstacles
 
@@ -133,7 +110,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -144,7 +120,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -157,3 +132,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC-TC/Testing/BB_Shadowing.md
+++ b/WorkInProgress/BB-SC-TC/Testing/BB_Shadowing.md
@@ -1,6 +1,4 @@
-
 # Shadowing
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC-TC
@@ -12,6 +10,9 @@ Testing
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -74,8 +75,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -103,7 +107,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -114,7 +117,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -127,3 +129,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2a-OSLayer/Container/BB_Container_Abstraction.md
+++ b/WorkInProgress/BB-SC/2a-OSLayer/Container/BB_Container_Abstraction.md
@@ -1,6 +1,4 @@
-
 # Container-Abstraction
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Container
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 OSLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -69,8 +70,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -98,7 +102,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -109,7 +112,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -122,3 +124,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2a-OSLayer/Time/BB_Automotive_Edge_Runtime.md
+++ b/WorkInProgress/BB-SC/2a-OSLayer/Time/BB_Automotive_Edge_Runtime.md
@@ -1,6 +1,4 @@
-
 # Automotive Edge Runtime
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -13,8 +11,10 @@ Time
 <!-- 1, 2a, 2b, 3 -->
 OSLayer
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 Eclipse Leda
 AutoSD (RHIVOS)
 
@@ -69,7 +69,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -88,8 +87,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -117,7 +119,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -128,7 +129,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -141,3 +141,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2a-OSLayer/Virtualization/BB_SR_VOSS.md
+++ b/WorkInProgress/BB-SC/2a-OSLayer/Virtualization/BB_SR_VOSS.md
@@ -1,6 +1,4 @@
-
 # SR VOSS
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Virtualization
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 OSLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -71,8 +72,11 @@ Closed Source
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -100,7 +104,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -112,7 +115,6 @@ Example:
  Incubating
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -125,3 +127,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Communication/BB_Communication_Protocol_Abstraction.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Communication/BB_Communication_Protocol_Abstraction.md
@@ -1,6 +1,4 @@
-
 # Communication Protocol Abstraction
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Communication
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -69,8 +70,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -98,7 +102,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -109,7 +112,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -122,3 +124,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Communication/BB_Communication_Server_S2S.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Communication/BB_Communication_Server_S2S.md
@@ -1,6 +1,4 @@
-
 # Communication Server (S2S)
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -11,6 +9,9 @@ Communication
 
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -54,7 +55,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -73,8 +73,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -101,9 +104,7 @@ Example:
 
 -->
 
-
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -114,7 +115,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -127,3 +127,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Communication/BB_Gateway_Mirroring.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Communication/BB_Gateway_Mirroring.md
@@ -1,6 +1,4 @@
-
 # Gateway Mirroring
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Communication
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -55,7 +56,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -74,8 +74,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -102,9 +105,7 @@ Example:
 
 -->
 
-
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -115,7 +116,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -128,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Communication/BB_Network_Management.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Communication/BB_Network_Management.md
@@ -1,6 +1,4 @@
-
 # Network Management
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Communication
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -55,7 +56,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -74,8 +74,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -102,9 +105,7 @@ Example:
 
 -->
 
-
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -115,7 +116,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -128,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Communication/BB_Onboard_TSN_configuration.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Communication/BB_Onboard_TSN_configuration.md
@@ -1,6 +1,4 @@
-
 # Onboard TSN configuration
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Communication
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -71,8 +72,11 @@ Closed source
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -100,7 +104,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -112,7 +115,6 @@ Example:
  Incubating
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -125,3 +127,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Communication/BB_SecOS.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Communication/BB_SecOS.md
@@ -1,6 +1,4 @@
-
 # SecOS
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Communication
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -57,7 +58,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -75,6 +75,10 @@ No – Commercial Closed Source -->
 ## Availability of API
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
+
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
 ## Potential obstacles
 
@@ -103,9 +107,7 @@ Example:
 
 -->
 
-
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -116,7 +118,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -129,3 +130,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Communication/BB_Smart_Charging_Communication.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Communication/BB_Smart_Charging_Communication.md
@@ -1,6 +1,4 @@
-
 # Smart Charging Communication
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -13,8 +11,10 @@ Communication
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 <https://lfenergy.org/projects/everest/>
 
 ## ID (unique name)
@@ -57,7 +57,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -76,8 +75,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -104,9 +106,7 @@ Example:
 
 -->
 
-
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -117,7 +117,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -130,3 +129,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Communication/BB_Standard_Android_VHAL.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Communication/BB_Standard_Android_VHAL.md
@@ -1,6 +1,4 @@
-
 # Standard Android VHAL
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -13,6 +11,9 @@ Communication
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
 
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
+
 ## Known Implementation
 
 ## ID (unique name)
@@ -24,7 +25,7 @@ The solution should be able to use any data middleware using VSS and standard tr
 
 a) definition and agreement of vendor mapping cross-OEM  
 b) OTA updatability  
-c) OEM specific mappings.  
+c) OEM specific mappings.
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
@@ -65,7 +66,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Anonymous
 
 ## Priority
@@ -84,8 +84,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -113,7 +116,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -124,7 +126,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -137,3 +138,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Communication/BB_TSN.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Communication/BB_TSN.md
@@ -1,6 +1,4 @@
-
 # TSN
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Communication
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -71,8 +72,11 @@ Closed source
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -100,7 +104,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -110,8 +113,8 @@ Example:
 - Abandoned
  -->
 Incubating
-## System Context
 
+## System Context
 <!-- 
 OS and runtime/framework requirements
 
@@ -124,3 +127,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Configuration/BB_Local_Update_Manager.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Configuration/BB_Local_Update_Manager.md
@@ -1,6 +1,4 @@
-
 # Local Update Manager
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,8 +10,10 @@ Configuration
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 - AUTOSAR: UCS - but not OSS-usable
 - higher-level: Eclipse Ankaios, Eclipse Kanto, Eclipse Symphony, Eclipse BlueChi
 
@@ -57,7 +57,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -76,8 +75,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -105,7 +107,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -116,7 +117,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -129,3 +129,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Configuration/BB_OTA_Master.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Configuration/BB_OTA_Master.md
@@ -1,6 +1,4 @@
-
 # OTA Master
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -13,8 +11,10 @@ Configuration
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 - AUTOSAR: UCS - but not OSS-usable
 - higher-level: Eclipse Ankaios, Eclipse Kanto, Eclipse Symphony, Eclipse BlueChi
 
@@ -33,7 +33,7 @@ Existing, IoT based implementations of OTA Master will not carry over to zonal a
 Reference to defined S-BB(s) 
 Reference to e.g. IS026262, AUTOSAR Spec. X -->
 OTA master POSIX  
-OTA master ASR Adaptive (UCM Master)  
+OTA master ASR Adaptive (UCM Master)
 
 ## Compose BB(s)
 <!-- Link to required BB(s) 
@@ -59,7 +59,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -78,8 +77,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -107,7 +109,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -118,7 +119,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -131,3 +131,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Diagnostics/BB_Policy_Manager.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Diagnostics/BB_Policy_Manager.md
@@ -1,6 +1,4 @@
-
 # Policy Manager
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Diagnostics
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -55,7 +56,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -73,6 +73,10 @@ No – Commercial Closed Source -->
 ## Availability of API
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
+
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
 ## Potential obstacles
 
@@ -102,7 +106,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -113,7 +116,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -126,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Diagnostics/BB_SOVD_Reference_implementation.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Diagnostics/BB_SOVD_Reference_implementation.md
@@ -1,6 +1,4 @@
-
 # SOVD Reference implementation
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Diagnostics
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -69,8 +70,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -98,7 +102,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -109,7 +112,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -122,3 +124,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Platform-Health-Management/BB_Distributed_Health_Management.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Platform-Health-Management/BB_Distributed_Health_Management.md
@@ -1,6 +1,4 @@
-
 # Distributed Health Management
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -13,8 +11,10 @@ Platform Health Management
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 <https://opentelemetry.io>
 
 ## ID (unique name)
@@ -37,7 +37,7 @@ concrete instantiation of a distributed health management concept is highly prod
 Reference to defined S-BB(s) 
 Reference to e.g. IS026262, AUTOSAR Spec. X -->
 AUTOSAR Classic  
-AUTOSAR Adaptive  
+AUTOSAR Adaptive
 
 ## Compose BB(s)
 <!-- Link to required BB(s) 
@@ -63,7 +63,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -82,8 +81,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -111,7 +113,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -122,7 +123,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -135,3 +135,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Platform-Health-Management/BB_Watchdog.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Platform-Health-Management/BB_Watchdog.md
@@ -1,6 +1,4 @@
-
 # Watchdog
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Platform Health Management
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -29,7 +30,7 @@ Watchdog is classically an ECU safety topic. For logical supervision and mitigat
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system
 Reference to defined S-BB(s) 
 Reference to e.g. IS026262, AUTOSAR Spec. X -->
-AUTOSAR Classic  
+AUTOSAR Classic
 
 ## Compose BB(s)
 <!-- Link to required BB(s) 
@@ -55,7 +56,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -74,8 +74,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -103,7 +106,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -114,7 +116,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -127,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Power-Management/BB_Power_Management_Coordination.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Power-Management/BB_Power_Management_Coordination.md
@@ -1,6 +1,4 @@
-
 # Power Management Coordination
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -13,6 +11,9 @@ Power Management
 <!-- 1, 2a, 2b, 3 -->
 <!-- NOTE: Flag -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -64,7 +65,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -83,8 +83,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -112,7 +115,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -123,7 +125,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -136,3 +137,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Runtime/BB_Diagnostic_Services_Applications.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Runtime/BB_Diagnostic_Services_Applications.md
@@ -1,6 +1,4 @@
-
 # Diagnostic Services Applications
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Runtime
 ## Layer
 <!-- 1, 2a, 2b, 3 -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -33,7 +34,7 @@ Reference to defined S-BB(s)
 Reference to e.g. IS026262, AUTOSAR Spec. X -->
 AUTOSAR Classic  
 AUTOSAR Adaptive  
-ASAM SOVD  
+ASAM SOVD
 
 ## Compose BB(s)
 <!-- Link to required BB(s) 
@@ -59,7 +60,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -78,8 +78,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -107,7 +110,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -118,7 +120,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -131,3 +132,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Runtime/BB_State_Management.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Runtime/BB_State_Management.md
@@ -1,6 +1,4 @@
-
 # State Management
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -13,8 +11,10 @@ Runtime
 <!-- 1, 2a, 2b, 3 -->
 MWLayer
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 Eclipse Piccolo
 
 ## ID (unique name)
@@ -64,7 +64,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -83,8 +82,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -112,7 +114,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -123,7 +124,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -136,3 +136,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Security/BB_Anomaly_Detection.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Security/BB_Anomaly_Detection.md
@@ -1,6 +1,4 @@
-
 # Anomaly Detection
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Security
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -78,8 +79,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -107,7 +111,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -118,7 +121,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -131,3 +133,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Security/BB_Crypto_Service_Manager.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Security/BB_Crypto_Service_Manager.md
@@ -1,6 +1,4 @@
-
 # Crypto Service Manager
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Security
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -32,7 +33,7 @@ Standardization facilitating integration at the ECU level.
 Reference to defined S-BB(s) 
 Reference to e.g. IS026262, AUTOSAR Spec. X -->
 AUTOSAR Classic  
-AUTOSAR Adaptive  
+AUTOSAR Adaptive
 
 ## Compose BB(s)
 <!-- Link to required BB(s) 
@@ -58,7 +59,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -77,8 +77,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -106,7 +109,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -117,7 +119,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -130,3 +131,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Security/BB_Internet_Protocol_Security.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Security/BB_Internet_Protocol_Security.md
@@ -1,6 +1,4 @@
-
 # Internet Protocol Security
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Security
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -56,7 +57,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -74,6 +74,10 @@ No – Commercial Closed Source -->
 ## Availability of API
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
+
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
 ## Potential obstacles
 
@@ -103,7 +107,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -114,7 +117,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -127,3 +129,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Security/BB_Intrusion_Detection.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Security/BB_Intrusion_Detection.md
@@ -1,6 +1,4 @@
-
 # Intrusion Detection
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Security
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -75,8 +76,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -104,7 +108,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -115,7 +118,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -128,3 +130,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Security/BB_Safety_Gateway.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Security/BB_Safety_Gateway.md
@@ -1,6 +1,4 @@
-
 # Safety-Gateway
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Security
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -71,8 +72,11 @@ Closed source; protect safety-relevant runtimes against unauthorized access
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -100,7 +104,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -112,7 +115,6 @@ Example:
  Incubating
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -125,3 +127,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Security/BB_Secure_Onboard_Communication.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Security/BB_Secure_Onboard_Communication.md
@@ -1,6 +1,4 @@
-
 # Secure Onboard Communication
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -13,6 +11,9 @@ Security
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -57,7 +58,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -76,8 +76,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -105,7 +108,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -116,7 +118,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -129,3 +130,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Security/BB_Security_Event_Manager.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Security/BB_Security_Event_Manager.md
@@ -1,6 +1,4 @@
-
 # Security Event Manager
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 SC-BB
@@ -12,6 +10,9 @@ Security
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -59,7 +60,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -78,8 +78,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -107,7 +110,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -118,7 +120,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -131,3 +132,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Security/BB_Security_Transport_Layer.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Security/BB_Security_Transport_Layer.md
@@ -1,6 +1,4 @@
-
 # Security Transport Layer
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Security
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLAyer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -29,7 +30,7 @@ Establish a common concept
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system
 Reference to defined S-BB(s) 
 Reference to e.g. IS026262, AUTOSAR Spec. X -->
-Internet TLS  
+Internet TLS
 
 ## Compose BB(s)
 <!-- Link to required BB(s) 
@@ -55,7 +56,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -74,8 +74,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -103,7 +106,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -114,7 +116,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -127,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Security/BB_Security_and_Safety_API.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Security/BB_Security_and_Safety_API.md
@@ -1,6 +1,4 @@
-
 # Security and Safety API
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Security
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -74,8 +75,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -103,7 +107,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -114,7 +117,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -127,3 +129,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Storage/BB_Vehicle_Data_Collector.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Storage/BB_Vehicle_Data_Collector.md
@@ -1,6 +1,4 @@
-
 # Vehicle Data Collector
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -13,8 +11,10 @@ Storage
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 <https://github.com/eclipse-sdv-blueprints/insurance>
 <https://github.com/eclipse-sdv-blueprints/fleet-management>
 
@@ -58,7 +58,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -77,8 +76,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -106,7 +108,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -117,7 +118,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -130,3 +130,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Storage/BB_Vehicle_Data_Persistency.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Storage/BB_Vehicle_Data_Persistency.md
@@ -1,6 +1,4 @@
-
 # Vehicle Data Persistency
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Storage
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -30,7 +31,7 @@ Standardized high level service for distributing persistent data on operating sy
 Reference to defined S-BB(s) 
 Reference to e.g. IS026262, AUTOSAR Spec. X -->
 AUTOSAR  
-Linux  
+Linux
 
 ## Compose BB(s)
 <!-- Link to required BB(s) 
@@ -56,7 +57,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -75,8 +75,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -104,7 +107,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -115,7 +117,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -128,3 +129,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Storage/BB_Vehicle_Logging_and_Recording.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Storage/BB_Vehicle_Logging_and_Recording.md
@@ -1,6 +1,4 @@
-
 # Vehicle Logging and Recording
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -13,8 +11,10 @@ Storage
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 OpenTelemetry
 
 ## ID (unique name)
@@ -33,7 +33,7 @@ One method known is the diagnostic log and trace ("Dlt") which could be used to 
 Reference to defined S-BB(s) 
 Reference to e.g. IS026262, AUTOSAR Spec. X -->
 AUTOSAR DLT  
-AUTOSAR XCP  
+AUTOSAR XCP
 
 ## Compose BB(s)
 <!-- Link to required BB(s) 
@@ -59,7 +59,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -78,8 +77,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -107,7 +109,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -118,7 +119,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -131,3 +131,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Time/BB_Onboard_TSN_scheduling_Tool.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Time/BB_Onboard_TSN_scheduling_Tool.md
@@ -1,6 +1,4 @@
-
 # Onboard TSN scheduling Tool
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Time
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -71,8 +72,11 @@ Closed source
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -100,7 +104,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -110,8 +113,8 @@ Example:
 - Abandoned
  -->
 Incubating
-## System Context
 
+## System Context
 <!-- 
 OS and runtime/framework requirements
 
@@ -124,3 +127,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Time/BB_Time_Service.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Time/BB_Time_Service.md
@@ -1,6 +1,4 @@
-
 # Time Service
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Time
 ## Layer
 <!-- 1, 2a, 2b, 3 -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -36,7 +37,7 @@ Reference to defined S-BB(s)
 Reference to e.g. IS026262, AUTOSAR Spec. X -->
 AUTOSAR-Classic  
 AUTOSAR Adaptive  
-Linux/Android Time  
+Linux/Android Time
 
 ## Compose BB(s)
 <!-- Link to required BB(s) 
@@ -62,7 +63,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -81,8 +81,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -110,7 +113,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -121,7 +123,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -134,3 +135,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/2b-MWLayer/Tools-and-Methods/BB_Key_Management_System.md
+++ b/WorkInProgress/BB-SC/2b-MWLayer/Tools-and-Methods/BB_Key_Management_System.md
@@ -1,6 +1,4 @@
-
 # Key Management System
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Tools and Methods
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -29,7 +30,7 @@ To be align with various HW existing solution (HSM, TEE, etc..)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system
 Reference to defined S-BB(s) 
 Reference to e.g. IS026262, AUTOSAR Spec. X -->
-AUTOSAR SecOc  
+AUTOSAR SecOc
 
 ## Compose BB(s)
 <!-- Link to required BB(s) 
@@ -55,7 +56,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -74,8 +74,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -103,7 +106,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -114,7 +116,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -127,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/3-AppLayer/API/BB_Automotive_API_Framework.md
+++ b/WorkInProgress/BB-SC/3-AppLayer/API/BB_Automotive_API_Framework.md
@@ -1,6 +1,4 @@
-
 # Automotive API Framework
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ API
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 AppLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -72,8 +73,11 @@ Apache 2.0
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -101,7 +105,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -113,7 +116,6 @@ Example:
  Incubating
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -126,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/3-AppLayer/Communication/BB_AOSP_Push_Notification_Service.md
+++ b/WorkInProgress/BB-SC/3-AppLayer/Communication/BB_AOSP_Push_Notification_Service.md
@@ -1,6 +1,4 @@
-
 # AOSP Push Notification Service
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -13,8 +11,10 @@ Communication
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 AppLayer
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 <https://novu.co>
 <https://unifiedpush.org/>
 
@@ -51,7 +51,7 @@ BB is a composition of other BBs -->
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
 BB Reference implementation  
-New standardized protocol  
+New standardized protocol
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
@@ -69,7 +69,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Anonymous
 
 ## Priority
@@ -91,8 +90,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -119,9 +121,7 @@ Example:
 
 -->
 
-
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -132,7 +132,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -145,3 +144,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/BB-SC/3-AppLayer/Control/BB_ADAAA.md
+++ b/WorkInProgress/BB-SC/3-AppLayer/Control/BB_ADAAA.md
@@ -1,6 +1,4 @@
-
 # ADAAA
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 BB-SC
@@ -12,6 +10,9 @@ Control
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 AppLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -72,8 +73,11 @@ MIT
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -101,7 +105,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -113,7 +116,6 @@ Example:
  Incubating
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -126,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/S-BB/2b-MWLayer/BB_Legally_binding_formats_for_data_exchange.md
+++ b/WorkInProgress/S-BB/2b-MWLayer/BB_Legally_binding_formats_for_data_exchange.md
@@ -1,7 +1,4 @@
-
 # Legally binding formats for data exchange
-
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -12,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -68,8 +68,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -97,7 +100,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -108,7 +110,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -121,3 +122,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/S-BB/2b-MWLayer/BB_SOA.md
+++ b/WorkInProgress/S-BB/2b-MWLayer/BB_SOA.md
@@ -1,6 +1,4 @@
-
 # SOA
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -12,8 +10,10 @@ S-BB
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 Eclipse uProtocol
 
 ## ID (unique name)
@@ -56,7 +56,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -75,8 +74,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -104,7 +106,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -115,7 +116,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -128,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/S-BB/2b-MWLayer/BB_Standardized_Data_Conversion_Tools_for_Info_Knowledge_Layers.md
+++ b/WorkInProgress/S-BB/2b-MWLayer/BB_Standardized_Data_Conversion_Tools_for_Info_Knowledge_Layers.md
@@ -1,6 +1,4 @@
-
 # Standardized Data Conversion Tools for Info-Knowledge Layers
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -11,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -56,7 +57,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Anonymous
 
 ## Priority
@@ -74,8 +74,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -103,7 +106,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -114,7 +116,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -127,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/S-BB/2b-MWLayer/BB_Standardized_Data_Description_for_Vehicle_Sensors_Attributes_Actuators.md
+++ b/WorkInProgress/S-BB/2b-MWLayer/BB_Standardized_Data_Description_for_Vehicle_Sensors_Attributes_Actuators.md
@@ -1,6 +1,4 @@
-
 # Standardized Data Description for Vehicle Sensors, Attributes, and Actuators
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -12,6 +10,9 @@ None
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -61,7 +62,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Anonymous
 
 ## Priority
@@ -79,8 +79,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -108,7 +111,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -119,7 +121,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -132,3 +133,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/S-BB/2b-MWLayer/BB_Standardized_HD_maps_formats.md
+++ b/WorkInProgress/S-BB/2b-MWLayer/BB_Standardized_HD_maps_formats.md
@@ -1,6 +1,4 @@
-
 # Stadardized HD maps formats and services
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -12,8 +10,10 @@ S-BB
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
 
-## Known Implementation
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
+## Known Implementation
 [HERE](https://www.here.com)
 
 ## ID (unique name)
@@ -69,8 +69,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -98,7 +101,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -109,7 +111,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -122,3 +123,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/S-BB/2b-MWLayer/BB_Standardized_authentication_of_vehicle_users.md
+++ b/WorkInProgress/S-BB/2b-MWLayer/BB_Standardized_authentication_of_vehicle_users.md
@@ -1,6 +1,4 @@
-
 # Standardized authentication of vehicle users
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -11,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -67,8 +68,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -96,7 +100,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -107,7 +110,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -120,3 +122,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/S-BB/2b-MWLayer/BB_Standardized_cloud_services_to_support_international_roaming_of_vehicles.md
+++ b/WorkInProgress/S-BB/2b-MWLayer/BB_Standardized_cloud_services_to_support_international_roaming_of_vehicles.md
@@ -1,6 +1,4 @@
-
 # Standardize cloud services to support international roaming of vehicles
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -11,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -67,8 +68,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -96,7 +100,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -107,7 +110,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -120,3 +122,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/S-BB/2b-MWLayer/BB_Standardized_data_formats_for_digital_twins.md
+++ b/WorkInProgress/S-BB/2b-MWLayer/BB_Standardized_data_formats_for_digital_twins.md
@@ -1,6 +1,4 @@
-
 # Standardized data formats for digital twins
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -11,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -67,8 +68,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -96,7 +100,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -107,7 +110,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -120,3 +122,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/S-BB/2b-MWLayer/BB_Standardized_way_for_Reasoning_on_Data_Streams.md
+++ b/WorkInProgress/S-BB/2b-MWLayer/BB_Standardized_way_for_Reasoning_on_Data_Streams.md
@@ -1,6 +1,4 @@
-
 # Standardized way for Reasoning on Data Streams
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -10,6 +8,9 @@ S-BB
 
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -55,7 +56,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Anonymous
 
 ## Priority
@@ -73,8 +73,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -102,7 +105,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -113,7 +115,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -126,3 +127,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/S-BB/2b-MWLayer/BB_sSOA.md
+++ b/WorkInProgress/S-BB/2b-MWLayer/BB_sSOA.md
@@ -1,6 +1,4 @@
-
 # sSOA
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -11,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 MWLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -30,7 +31,7 @@ Get standardized solution whereas today each vehicle manufacturers bring its sol
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system
 Reference to defined S-BB(s) 
 Reference to e.g. IS026262, AUTOSAR Spec. X -->
-AUTOSAR SCREIAM  
+AUTOSAR SCREIAM
 
 ## Compose BB(s)
 <!-- Link to required BB(s) 
@@ -56,7 +57,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Conti
 
 ## Priority
@@ -75,8 +75,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -104,7 +107,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -115,7 +117,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -128,3 +129,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/S-BB/3-AppLayer/API/BB_VAPI_Stack_Demonstrator.md
+++ b/WorkInProgress/S-BB/3-AppLayer/API/BB_VAPI_Stack_Demonstrator.md
@@ -1,6 +1,4 @@
-
 # VAPI Stack Demonstrator
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -11,6 +9,9 @@ API
 
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -68,8 +69,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -97,7 +101,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -108,7 +111,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -121,3 +123,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/S-BB/3-AppLayer/BB_Fleet_Management_System.md
+++ b/WorkInProgress/S-BB/3-AppLayer/BB_Fleet_Management_System.md
@@ -1,6 +1,4 @@
-
 # Fleet Management System
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -11,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 AppLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -69,8 +70,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -98,7 +102,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -109,7 +112,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -122,3 +124,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/S-BB/3-AppLayer/BB_Standardization_of_Vehicle_API.md
+++ b/WorkInProgress/S-BB/3-AppLayer/BB_Standardization_of_Vehicle_API.md
@@ -1,6 +1,4 @@
-
 # Standardization of Vehicle API
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -11,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 AppLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -58,7 +59,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Anonymous
 
 ## Priority
@@ -75,6 +75,10 @@ No – Commercial Closed Source -->
 ## Availability of API
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
+
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
 ## Potential obstacles
 
@@ -104,7 +108,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -115,7 +118,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -128,3 +130,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/S-BB/3-AppLayer/BB_Standardized_Architectural_Patterns_for_Cross_Platform_Data_Service_Infrastructure.md
+++ b/WorkInProgress/S-BB/3-AppLayer/BB_Standardized_Architectural_Patterns_for_Cross_Platform_Data_Service_Infrastructure.md
@@ -1,6 +1,4 @@
-
 # Standardized Architectural Patterns for Cross Platform Data Service Infrastructure
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -11,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 AppLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -56,7 +57,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Anonymous
 
 ## Priority
@@ -74,8 +74,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -103,7 +106,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -114,7 +116,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -127,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/S-BB/3-AppLayer/BB_Standardized_Description_of_Data_from_Related_Domains.md
+++ b/WorkInProgress/S-BB/3-AppLayer/BB_Standardized_Description_of_Data_from_Related_Domains.md
@@ -1,6 +1,4 @@
-
 # Standardized Description of Data from Related Domains
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -11,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 AppLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -56,7 +57,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Anonymous
 
 ## Priority
@@ -74,8 +74,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -103,7 +106,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -114,7 +116,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -127,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/S-BB/3-AppLayer/BB_Standardized_Procedure_and_Tooling_for_Combining_Data_from_Different_Domains.md
+++ b/WorkInProgress/S-BB/3-AppLayer/BB_Standardized_Procedure_and_Tooling_for_Combining_Data_from_Different_Domains.md
@@ -1,6 +1,4 @@
-
 # Standardized Procedure and Tooling for Combining Data from Different Domains
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -11,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 AppLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -56,7 +57,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Anonymous
 
 ## Priority
@@ -74,8 +74,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -103,7 +106,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -114,7 +116,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -127,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/WorkInProgress/S-BB/3-AppLayer/BB_Standardized_Procedure_and_Tooling_for_Modelling_Data_from_Different_Domains.md
+++ b/WorkInProgress/S-BB/3-AppLayer/BB_Standardized_Procedure_and_Tooling_for_Modelling_Data_from_Different_Domains.md
@@ -1,6 +1,4 @@
-
 # Standardized Procedure and Tooling for Modelling Data from Different Domains
-
 ## BB Tags(s)
 <!-- Tag(s) define in which area(s) (cloud, in-vehicle) the BB is executed, and what type of BB it is (tool, process, microservice) -->
 S-BB
@@ -11,6 +9,9 @@ S-BB
 ## Layer
 <!-- AppLayer, MWLayer, OSLayer, HWLayer -->
 AppLayer
+
+## BB Usage
+<!-- example on how to use BB or link to documentation -->
 
 ## Known Implementation
 
@@ -24,7 +25,7 @@ Developing a standardized methodology and toolkit for data modeling in the softw
 <!-- Explanation why we need the BB; what problem want to be solved -->
 In the context of software-defined vehicles, this work package standardizes data modeling to enhance integration and streamline development, thus supporting advanced, data-driven automotive applications.  
 
-Example usage: Employing cross-domain data modeling for automotive manufacturers, technology developers, and research institutions focused on software defined vehicles  
+Example usage: Employing cross-domain data modeling for automotive manufacturers, technology developers, and research institutions focused on software defined vehicles
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system
@@ -56,7 +57,6 @@ If “No” – nothing more to do
 If “Yes, proposal for additional Signals/Information – what should be made available, and where e.g. via (COVESA) VSS/VISS -->
 
 ## Author/Company
-
 Anonymous
 
 ## Priority
@@ -74,8 +74,11 @@ No – Commercial Closed Source -->
 <!-- Yes / License (e.g. Yes/Apache 2.0)
 No - Commercial -->
 
-## Potential obstacles
+## Type of API
+<!-- Web API, Library/Framework API, Operating System API, Database API, Remote API, Hardware API, Other -->
+None
 
+## Potential obstacles
 
 ## Maturity Badges
 <!-- taken over from Eclipse SDV Process 
@@ -103,7 +106,6 @@ Example:
 -->
 
 ## State (+ date of last change)
-
 <!-- 
 - Incubating (no code yet)
 - Implementation started
@@ -114,7 +116,6 @@ Example:
  -->
 
 ## System Context
-
 <!-- 
 OS and runtime/framework requirements
 
@@ -127,3 +128,6 @@ eg.
 - web assembly
 - web service
  -->
+
+## Bazel compliance status
+<!-- The S-CORE project requires all BB contributions to be ready for BAZEL compliant (https://github.com/bazelbuild/bazel)-->

--- a/other/scripts/bb_standardizer.py
+++ b/other/scripts/bb_standardizer.py
@@ -1,0 +1,162 @@
+import os
+import re
+from io import StringIO
+import logging
+
+template_data = []
+
+def building_block_rewrite():
+    template_file_path = "other/utils/BB_Template.md"
+    global template_data
+    template_data = extract_template_headings_and_content(template_file_path)
+
+    directory = os.path.join(os.getcwd(), os.pardir)
+    excluded_dirs = [".github", ".venv", "other", "UseCases"]
+    keyword = "BB"
+    markdown_files = find_markdown_files(directory, excluded_dirs, keyword)
+
+    for file in markdown_files:
+        scan_bb_file(file)
+
+def extract_template_headings_and_content(file_path):
+    """
+    Extract headings and their content from a the BB template file.
+
+    Args:
+        file_path (str): Path to the markdown file.
+    Returns:
+        dict: Dictionary with headings as keys and their content as values.
+    """
+    name_pattern = re.compile(r"# ([a-zA-Z0-9, +\-\ \/(\)]*)\s*## BB Tag")
+    heading_pattern = re.compile(r"## ([a-zA-Z +\-\/\(\)]*)")
+
+    with open(file_path, "r", encoding="utf-8") as file:
+        content = file.read()
+
+    headings = heading_pattern.findall(content)
+    names = name_pattern.findall(content)
+
+    if not names:
+        raise ValueError(f"No BB Name found in {file_path}")
+
+
+    heading_contents = {"BB Name": names[0]}
+
+    for i, heading in enumerate(headings):
+        start = content.find(heading) + len(heading)
+        end = content.find(headings[i + 1]) if i + \
+            1 < len(headings) else len(content)
+        
+        heading_content = content[start:end].strip("\r\n# ")
+        heading_contents[heading] = heading_content
+
+    return heading_contents
+
+def scan_bb_file(file_path):
+    """
+    Checks BB file for missing headings or unspecified headings with template file as a reference.
+    If any headings are missing or the file contains unspecified headings, the fix_markdown_file function is called.
+
+    Args:
+        file_path (str): Path to the markdown file.
+    """
+    name_pattern = re.compile(r"# ([a-zA-Z0-9, +\-\ \/(\)]*)\s*## BB Tag")
+    heading_pattern = re.compile(r"## ([a-zA-Z +\-\/\(\)]*)")
+
+    missing_headings = []
+    # if there are any headings in the file not specified in the template, the file will be rewritten without the unsepcified heading
+    contains_unspecified_headings = False
+
+    with open(file_path, "r", encoding="utf-8") as file:
+        content = file.read()
+
+    headings = heading_pattern.findall(content)
+    names = name_pattern.findall(content)
+
+    if not names:
+        raise ValueError(f"No BB Name found in {file_path}")
+
+
+    heading_contents = {"BB Name": names[0]}
+
+    end = 0
+
+    for i, heading in enumerate(headings):
+        if heading not in template_data:
+            logging.warning(f"Wrong template in {file_path}, contains unspecified heading: {heading}.")
+            contains_unspecified_headings = True
+            continue
+        start = end + content[end:].find(heading) + len(heading)
+        end = start + content[start:].find(headings[i + 1]) if i + \
+            1 < len(headings) else len(content)
+        
+        heading_content = content[start:end].strip("\r\n# ")
+        heading_contents[heading] = heading_content
+
+        heading_contents[heading] = heading_content
+    if len(heading_contents) < len(template_data):
+        template_diff = list(set(template_data).difference(heading_contents))
+        logging.warning(f"Missing heading(s) specified in template in file {file_path}. Missing headings: {template_diff}")
+        missing_headings.append(template_diff)
+        missing_headings = missing_headings[0]
+
+    if len(missing_headings) > 0 or contains_unspecified_headings:
+        heading_contents = fix_markdown_file(file_path, heading_contents, missing_headings)
+    
+def find_markdown_files(directory, excluded_dirs, keyword):
+    """
+    Traverse the directory to find markdown files that include a specific keyword.
+
+    Args:
+        directory (str): The root directory to start the search.
+        excluded_dirs (list): List of directories to exclude from the search.
+        keyword (str): Keyword to filter markdown files.
+
+    Returns:
+        list: List of markdown file paths that match the criteria.
+    """
+    markdown_files = []
+    for root, dirs, files in os.walk(directory):
+        dirs[:] = [d for d in dirs if d not in excluded_dirs]
+        for file in files:
+            if file.endswith(".md") and keyword in file:
+                markdown_files.append(os.path.join(root, file))
+    return markdown_files
+
+def fix_markdown_file(file, content, missing_headings):
+    """
+    Add missing headings to file at the appropriate position. 
+    Rewrite the file with the new headings and invalid headings removed.
+
+    Args:
+        file (str): Path to building block file to be rewritten.
+        content (dict): Contents of the file.
+        missing_headings (list): List containing missing headings in the file according to the template.
+    """
+    for misssing_heading in missing_headings:
+        position = list(template_data.keys()).index(misssing_heading)
+        items = list(content.items())
+        items.insert(position, (misssing_heading, template_data[misssing_heading]))
+        content = dict(items)
+
+    file_content = StringIO()
+    file_content.write("# " + content["BB Name"] + "\n")
+    content.pop("BB Name")
+
+    i = 0
+    for heading, data in content.items():
+        file_content.write("## " + heading + "\n")
+        file_content.write(data)
+        if i+1 < len(content):
+            if len(data) > 0:
+                file_content.write("\n\n")
+            else:
+                file_content.write("\n")
+        i = i + 1
+
+    with open(file, "w", encoding="utf-8") as f:
+        f.write(file_content.getvalue())
+
+
+if __name__ == "__main__":
+    building_block_rewrite()

--- a/other/scripts/bb_standardizer.py
+++ b/other/scripts/bb_standardizer.py
@@ -145,6 +145,9 @@ def fix_markdown_file(file, content, missing_headings):
 
     i = 0
     for heading, data in content.items():
+        # special logic for API Type, if nothing is written, then the text 'None' is added
+        if heading == "API Type" and not data.strip(" \n\r"):
+            data = 'None'
         file_content.write("## " + heading + "\n")
         file_content.write(data)
         if i+1 < len(content):

--- a/other/scripts/bb_standardizer.py
+++ b/other/scripts/bb_standardizer.py
@@ -146,8 +146,12 @@ def fix_markdown_file(file, content, missing_headings):
     i = 0
     for heading, data in content.items():
         # special logic for API Type, if nothing is written, then the text 'None' is added
-        if heading == "API Type" and not data.strip(" \n\r"):
-            data = 'None'
+        if heading == "Type of API":
+            comment_pattern = re.compile(r"<!--.*-->")
+            comment = comment_pattern.findall(data)[0]
+            data_no_comment = data.replace(comment,"")
+            if not data_no_comment:
+                data = data + "\nNone"
         file_content.write("## " + heading + "\n")
         file_content.write(data)
         if i+1 < len(content):


### PR DESCRIPTION
Added a script for bringing BBs into a common format. All BBs receive only the headings specified in the template file. Trailing whitespaces and extra line breaks are removed. Also adding 'None' to the Type of API heading since the heading was newly added.