### PR TITLE
Rework release workflow

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -16,6 +16,7 @@ jobs:
           with:
             ssh-key: ${{ secrets.DEPLOY_KEY }}
             ref: main
+            fetch-depth: 0
         - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
         - name: List files in the repository
           run: |
@@ -30,6 +31,24 @@ jobs:
               pip install pandas openpyxl
         - name: execute py script 
           run: python other/scripts/output_file_generator.py ${{github.workspace}}
+        - name: generate release notes
+          shell: bash
+          run: |
+            START_DATE=$(date -d "$(date +%Y-%m-01) -1 month" +%Y-%m-01)
+            END_DATE=$(date -d "$(date +%Y-%m-01) -1 day" +%Y-%m-%d)
+
+            MONTH_LABEL=$(date -d "$START_DATE" +'%B %Y:')
+
+            echo "# Commits in $MONTH_LABEL" > RELEASE_NOTES.md
+            echo "" >> RELEASE_NOTES.md
+
+            git log \
+            --since="$START_DATE" \
+            --until="$END_DATE 23:59:59" \
+            --date=format:'%a %b %e' \
+            --pretty=format:'- %ad — %s (%an)' \
+            >> RELEASE_NOTES.md
+
         - name: determine tag name
           id: vars
           shell: bash
@@ -43,5 +62,6 @@ jobs:
             tag_name: ${{ steps.vars.outputs.tag }}
             name: ${{ steps.vars.outputs.release_name }}
             generate_release_notes: false
+            body_path: RELEASE_NOTES.md
             files: |
               output.xlsx


### PR DESCRIPTION
The current release workflow includes a changelog with every contribution to the repo dating years into the past.

With this rework, only the commits of the previous month are included in the changelog. An example for the new changelog looks like this:

Commits in January 2026:
- Fri Jan 23: reworking release workflow to no longer include release notes (Simon Pusterhofer)