### PR TITLE
112 general monthly release doesnt contain xls anymore since may 1st 2026

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -63,5 +63,6 @@ jobs:
             name: ${{ steps.vars.outputs.release_name }}
             generate_release_notes: false
             body_path: RELEASE_NOTES.md
+            fail_on_unmatched_files: true            
             files: |
               output.xlsx

--- a/other/scripts/output_file_generator.py
+++ b/other/scripts/output_file_generator.py
@@ -65,7 +65,7 @@ def extract_headings_and_content(file_path, is_template_file = False):
     Returns:
         dict: Dictionary with headings as keys and their content as values.
     """
-    name_pattern = re.compile(r"# ([a-zA-Z0-9., +\-\ \/(\)]*)\s*## BB Tag")
+    name_pattern = re.compile(r"# ([a-zA-Z0-9.,:— +\-\ \/(\)]*)\s*## BB Tag")
     heading_pattern = re.compile(r"## ([a-zA-Z +\-\/\(\)]*)")
     file_path_pattern = re.compile(r"(?:Proposed-BuildingBlocks\\)(.*)")
 
@@ -211,7 +211,7 @@ def main():
             logging.info(f"Excel file successfully created at {output_file_path}")
     except Exception as e:
         logging.error(f"An error occurred: {e}")
-
+        raise   # 20260604pp: Re-raise the exception after logging it to ensure that the error is not silently ignored.
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
fixed monthly generation of XLS file.
Main reason was that some newly added BB descriptions now used ":" and em-dash as part of the BB name. => adapted regex def.
Also, XLS generation failed silently. Missing XLS was found by chance -> changed so release will report failure
