### PR TITLE
Improve descriptions and documentation of entire catalog

### DIFF
--- a/BB-CEST/BB_Eclipse_CSP.md
+++ b/BB-CEST/BB_Eclipse_CSP.md
@@ -13,7 +13,7 @@ APPLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Eclipse CSP provides cloud-side building blocks for connected vehicle services. OEMs integrate the platform to manage vehicle data ingestion, device lifecycle, user profiles, and notification routing. Documentation and getting started guides are available at https://eclipse-ecsp.github.io/ecsp-website/.
 
 ## Known Implementation
 https://eclipse-ecsp.github.io/ecsp-website/
@@ -26,6 +26,7 @@ Eclipse Connected Services Platform (CSP) offers a comprehensive platform with a
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Automotive OEMs require a reusable, open-source cloud services platform to build connected vehicle solutions without developing common capabilities (data management, device management, notifications) from scratch. Eclipse CSP addresses this by providing a vendor-neutral foundation for SDV cloud backends.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-CEST/Data-Processing-and-Management/BB_Eclipse_TractusX.md
+++ b/BB-CEST/Data-Processing-and-Management/BB_Eclipse_TractusX.md
@@ -13,7 +13,7 @@ APPLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Tractus-X provides reference implementations for Catena-X data exchange use cases (traceability, PCF exchange, demand/capacity management). Participants deploy Tractus-X components (EDC connectors, digital twin registry, portal) to join the Catena-X data space. See https://eclipse-tractusx.github.io/ for tutorials and integration guides.
 
 ## Known Implementation
 https://github.com/eclipse-tractusx
@@ -26,6 +26,7 @@ Eclipse Tractus-X is a collaborative, open-source project aimed at driving the d
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+The automotive supply chain requires sovereign, standardized data exchange across organizational boundaries. Tractus-X enables interoperable, trust-based collaboration (e.g., traceability, carbon footprint tracking) while ensuring each participant retains control over their data.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_Eclipse_Cloe.md
+++ b/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_Eclipse_Cloe.md
@@ -13,7 +13,7 @@ AppLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Cloe acts as simulation middleware for automated driving development. Developers plug in their AD components via Cloe's unified interface and run closed-loop simulations with configurable sensor models, triggers, and scenarios. Documentation is available at https://cloe.readthedocs.io/en/latest/.
 
 ## Known Implementation
 https://cloe.readthedocs.io/en/latest/
@@ -37,7 +37,7 @@ Using these abstractions, it is then possible to provide features such as the fo
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
-TBD
+Automated driving software must be validated in simulation before road testing. Cloe provides a simulator-agnostic middleware layer that decouples AD components from specific simulation backends, enabling reproducible CI-integrated testing with fault injection and ground-truth data.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_Eclipse_Mosaic.md
+++ b/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_Eclipse_Mosaic.md
@@ -13,7 +13,7 @@ AppLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Documentation: https://eclipse.dev/mosaic/docs/. MOSAIC couples multiple domain simulators (traffic, network, vehicle, application) through its Runtime Infrastructure (RTI) for multi-domain co-simulation scenarios.
 
 ## Known Implementation
 https://github.com/eclipse-mosaic/mosaic
@@ -26,7 +26,7 @@ Eclipse MOSAIC is a multi-scale simulation framework in the field of smart and c
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
-TBD
+SDV testing requires multi-domain co-simulation combining traffic, network, vehicle dynamics, and application behavior to validate connected and automated driving functions.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_Eclipse_SCM.md
+++ b/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_Eclipse_SCM.md
@@ -13,7 +13,7 @@ AppLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+SCM is used for stochastic traffic flow simulations to statistically analyze critical driving situations and accident occurrence. Researchers configure driver behaviour parameters and run Monte Carlo simulations to assess vehicle safety. See https://gitlab.eclipse.org/eclipse/scm/scm for documentation.
 
 ## Known Implementation
 https://gitlab.eclipse.org/eclipse/scm/scm
@@ -27,7 +27,7 @@ SCM focuses on detailed driver behaviour modelling to provide an accurate simula
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
-TBD
+Validating automated driving safety requires statistical evidence from large-scale traffic simulations with realistic driver behaviour models. SCM provides stochastic, cause-action-based driver modelling to generate critical scenario data for safety assessment.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_Eclipse_SUMO.md
+++ b/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_Eclipse_SUMO.md
@@ -13,7 +13,7 @@ AppLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Documentation: https://sumo.dlr.de/docs/. SUMO provides command-line tools for traffic simulation, and the TraCI (Traffic Control Interface) API for runtime control of simulations from external scripts (Python, C++, Java).
 
 ## Known Implementation
 https://eclipse.dev/sumo/
@@ -26,7 +26,7 @@ SUMO allows modelling of intermodal traffic systems including road vehicles, pub
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
-TBD
+Automotive development needs traffic simulation for testing V2X, ADAS, and connected driving scenarios in a reproducible, scalable environment before real-world deployment.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_Eclipse_esmini.md
+++ b/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_Eclipse_esmini.md
@@ -13,7 +13,7 @@ AppLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-Esmini is used as a lightweight OpenSCENARIO player and OpenDRIVE road network engine. Integrate via the C API (esminiLib/esminiRMLib) into C++, Unity3D, MATLAB/Simulink, or other frameworks to replay and visualize traffic scenarios. Supports Windows, Mac, Linux. See https://github.com/EnvironmentSimulator/esmini for examples.
+Esmini is used as a lightweight OpenSCENARIO player and OpenDRIVE road network engine. Integrate via the C API (esminiLib/esminiRMLib) into C++, Unity3D, MATLAB/Simulink, or other frameworks to replay and visualize traffic scenarios. Supports Windows, Mac, Linux. See https://github.com/esmini/esmini for examples.
 
 ## Known Implementation
 https://eclipse.dev/sumo/

--- a/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_Eclipse_esmini.md
+++ b/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_Eclipse_esmini.md
@@ -13,7 +13,7 @@ AppLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Esmini is used as a lightweight OpenSCENARIO player and OpenDRIVE road network engine. Integrate via the C API (esminiLib/esminiRMLib) into C++, Unity3D, MATLAB/Simulink, or other frameworks to replay and visualize traffic scenarios. Supports Windows, Mac, Linux. See https://github.com/EnvironmentSimulator/esmini for examples.
 
 ## Known Implementation
 https://eclipse.dev/sumo/

--- a/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_Eclipse_openPASS.md
+++ b/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_Eclipse_openPASS.md
@@ -13,7 +13,7 @@ AppLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Documentation and downloads: https://openpass.eclipse.org/. Configure simulation scenarios to assess the effectiveness of ADAS/AD safety systems through statistical Monte Carlo analysis.
 
 ## Known Implementation
 https://openpass.eclipse.org/
@@ -26,7 +26,7 @@ The openPASS (open Platform for Assessment of Safety Systems) platform is being 
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
-TBD
+ADAS/AD safety assessment requires statistical simulation of traffic scenarios to evaluate safety system effectiveness before deployment on public roads.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_Lichtblick.md
+++ b/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_Lichtblick.md
@@ -13,7 +13,7 @@ AppLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Lichtblick can be used as a desktop application or in the browser to visualize and debug robotics and vehicle data. It supports loading ROS bag files, connecting to live ROS topics, and rendering sensor data (lidar point clouds, camera images, maps) in configurable panels. See documentation at https://github.com/Lichtblick-Suite/lichtblick.
 
 ## Known Implementation
 https://github.com/Lichtblick-Suite/lichtblick
@@ -26,7 +26,7 @@ Lichtblick is an integrated visualization and diagnosis tool for robotics, avail
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
-TBD
+Developers of autonomous driving and ADAS functions need an integrated visualization and diagnostic tool to inspect sensor data, vehicle state, and simulation outputs. Lichtblick provides a cross-platform, open-source solution for real-time and recorded data visualization, reducing dependency on proprietary tooling.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_OSTAR.md
+++ b/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_OSTAR.md
@@ -13,7 +13,7 @@ AppLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Use the OSTAR-Quickstart repository to set up a co-simulation environment where FMI-packaged vehicle models are integrated into CARLA via OSI messages. Models communicate through GroundTruth, SensorView, and TrafficUpdate interfaces. See https://github.com/DLR-TS/OSTAR-Quickstart for setup and usage instructions.
 
 ## Known Implementation
 https://github.com/DLR-TS/OSTAR-Quickstart
@@ -26,7 +26,7 @@ The scientific project OSTAR is a set of software tools for automotive simulatio
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
-TBD
+Automotive simulation requires standardized integration of diverse vehicle models with virtual environments. OSTAR solves the interoperability problem by combining FMI for model packaging and OSI for sensor/environment communication, enabling automated test orchestration and reproducible simulation results across different toolchains.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_SODAsim.md
+++ b/BB-CEST/Development-Testing-and-Simulation-Environments/Simulation-and-Emulation-Tools/BB_SODAsim.md
@@ -13,7 +13,7 @@ AppLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+SODA.Sim provides a distributed simulation environment for SDV development. Users configure vehicle models at the atomic component level (sensors, ECUs, vehicle systems) and run validation scenarios covering AD/ADAS functions. See https://github.com/soda-auto/soda-sim for setup and integration guides.
 
 ## Known Implementation
 https://github.com/soda-auto/soda-sim
@@ -28,7 +28,7 @@ By simulating vehicles at the level of atomic components, such as sensors, vehic
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
-TBD
+Software-defined vehicles require continuous validation from concept through certification to aftermarket updates. SODA.Sim addresses the need for a distributed, component-level simulation platform that can serve as a virtual proving ground, reducing the cost and time of physical testing while enabling comprehensive coverage of vehicle function validation.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-CEST/Operations-and-Maintenance/Automation-and-Orchestration/BB_Eclipse_PullPiriPackageService.md
+++ b/BB-CEST/Operations-and-Maintenance/Automation-and-Orchestration/BB_Eclipse_PullPiriPackageService.md
@@ -13,7 +13,7 @@ AppLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+The PULLPIRI Package Service manages OTA software packages for vehicle fleets. Operators define update policies and package manifests; the service handles package versioning, distribution, and rollback. See https://github.com/eclipse-pullpiri/pullpiri for setup and API documentation.
 
 ## Known Implementation
 https://github.com/eclipse-pullpiri/pullpiri
@@ -26,7 +26,7 @@ The main goal of PULLPIRI project is to develop an efficient vehicle service orc
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
-TBD
+SDV platforms require reliable, policy-driven OTA package management to deploy and update in-vehicle services at scale. PULLPIRI provides this capability with short development cycles and context-aware activation of vehicle scenarios.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-CEST/Operations-and-Maintenance/Automation-and-Orchestration/BB_Eclipse_SymphonyOrchestrationLayer.md
+++ b/BB-CEST/Operations-and-Maintenance/Automation-and-Orchestration/BB_Eclipse_SymphonyOrchestrationLayer.md
@@ -13,7 +13,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Symphony provides a unified orchestration layer for managing workloads across heterogeneous edge and cloud devices. Operators define desired-state configurations; Symphony reconciles them across targets without requiring changes to existing systems. See https://eclipse-symphony.github.io/symphony-website/ for documentation.
 
 ## Known Implementation
 https://eclipse-symphony.github.io/symphony-website/
@@ -26,7 +26,7 @@ Project Symphony is an Eclipse Foundation open-source orchestration platform tha
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
-TBD
+SDV cloud backends must orchestrate workloads across diverse devices and vendors with a consistent workflow. Symphony addresses the complexity of multi-target orchestration by providing a single control plane that integrates existing systems without modification.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-CEST/Operations-and-Maintenance/Monitoring-and-Observability/BB_Eclipse_AnkaiosDashboard.md
+++ b/BB-CEST/Operations-and-Maintenance/Monitoring-and-Observability/BB_Eclipse_AnkaiosDashboard.md
@@ -13,7 +13,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+The Ankaios Dashboard provides a web-based UI for monitoring and managing workloads running in an Ankaios cluster. Users can view workload status, create/modify/delete workloads, and inspect dependency graphs. See https://github.com/eclipse-ankaios-dashboard/ankaios-dashboard for installation and usage.
 
 ## Known Implementation
 https://github.com/eclipse-ankaios-dashboard/ankaios-dashboard
@@ -26,7 +26,7 @@ The Ankaios Dashboard ist the ui interface for Eclipse Ankaios project. It offer
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
-TBD
+Operators and developers need visual insight into Ankaios workload orchestration state. The dashboard lowers the barrier to understanding workload dependencies and cluster health without requiring CLI expertise.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-CEST/Operations-and-Maintenance/Monitoring-and-Observability/BB_Eclipse_MutoDashboard.md
+++ b/BB-CEST/Operations-and-Maintenance/Monitoring-and-Observability/BB_Eclipse_MutoDashboard.md
@@ -13,7 +13,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+The Muto Dashboard provides a web interface for monitoring device-level Muto deployments. It visualizes active stacks, runtime state, and adaptive behaviors across connected vehicles and robotic platforms. See https://github.com/eclipse-muto/dashboard-device for setup instructions.
 
 ## Known Implementation
 https://github.com/eclipse-muto/dashboard-device
@@ -26,7 +26,7 @@ Muto is a context aware software solution to address some of the runtime adaptiv
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
-TBD
+Context-aware adaptive software stacks require observability tooling to monitor runtime state and dynamic reconfiguration across distributed vehicles. The Muto Dashboard provides this visibility for operators managing Muto-based deployments.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-CSC-TC/RapidPrototyping/BB_EclipseAutoWRX.md
+++ b/BB-CSC-TC/RapidPrototyping/BB_EclipseAutoWRX.md
@@ -13,7 +13,7 @@ APPLayer, MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+AutoWRX enables rapid prototyping of SDV applications using the digital.auto playground. Developers model vehicle APIs (based on COVESA VSS), create prototypes in-browser, and validate concepts with the dreamKIT toolchain. Access the platform at https://www.digital.auto/ and source at https://github.com/eclipse-autowrx.
 
 ## Known Implementation
 https://github.com/eclipse-autowrx

--- a/BB-EST/Build-and-Implementation/BB_VELOCITAS.md
+++ b/BB-EST/Build-and-Implementation/BB_VELOCITAS.md
@@ -13,7 +13,15 @@ Build and Implementation
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Documentation: https://eclipse.dev/velocitas/
 
+Velocitas provides project templates for Vehicle Apps in Python and C++:
+- Python template: https://github.com/eclipse-velocitas/vehicle-app-python-template
+- C++ template: https://github.com/eclipse-velocitas/vehicle-app-cpp-template
+
+The Velocitas CLI manages project lifecycle, package installation, and code generation. DevContainers are provided for a ready-to-use development environment.
+
+Support channels: https://app.gitter.im/#/room/#eclipse-velocitas_community:gitter.im
 
 ## Known Implementation
 https://github.com/eclipse-velocitas
@@ -26,6 +34,7 @@ Eclipse Velocitas provides a development toolchain to create containerized in-ve
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Developing containerized in-vehicle applications today requires assembling a complex toolchain from scratch — build systems, vehicle model generation, testing harnesses, deployment pipelines. Velocitas provides an opinionated, ready-to-use development toolchain specifically designed for Vehicle Apps, reducing onboarding time and increasing development velocity. It abstracts vehicle data access through generated vehicle models based on VSS, enabling developers to focus on application logic rather than integration plumbing.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-EST/Build-and-Implementation/BB_VELOCITAS.md
+++ b/BB-EST/Build-and-Implementation/BB_VELOCITAS.md
@@ -50,17 +50,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Python 3 or C++ toolchain. VS Code with DevContainers. Velocitas CLI (TypeScript/Node.js).
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+DevContainer environment (Docker). Target: containerized Vehicle Apps deployable to any container runtime.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+Developer productivity focus. Not safety-certified.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-
+FC Communication (KUKSA Databroker for vehicle data access, VSS for signal model).
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-EST/Build-and-Implementation/Embedded-Linux/BB_YoctoProject.md
+++ b/BB-EST/Build-and-Implementation/Embedded-Linux/BB_YoctoProject.md
@@ -63,20 +63,20 @@ TBD
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
--
+BitBake, OpenEmbedded layers, Python, Shell scripting
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
-Linux build envrionment
+Linux build host (Ubuntu/Fedora recommended). 100+ GB disk, 8+ GB RAM for builds.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Reproducible builds. Layer-based customization. Industry standard for embedded Linux.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+None (meta-build system). Produces complete Linux distributions.
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-EST/Build-and-Implementation/Embedded-Linux/BB_YoctoProject.md
+++ b/BB-EST/Build-and-Implementation/Embedded-Linux/BB_YoctoProject.md
@@ -12,7 +12,7 @@ BB-EST, BB-CEST
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Documentation: https://www.yoctoproject.org/docs/. Use BitBake recipes and layers to define custom Linux distributions. Create BSP layers for target hardware and application layers for platform-specific software stacks.
 
 ## Known Implementation
 https://git.yoctoproject.org/

--- a/BB-EST/Design/BB_SKyBT.md
+++ b/BB-EST/Design/BB_SKyBT.md
@@ -14,7 +14,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Test designers model the system under test using keyword-based syntax (Signal/Knowledge/Behavior Trees). From these models, test cases are generated automatically and exported to ALM tools or executed directly in test automation frameworks. See https://gitlab.eclipse.org/eclipse/skybt/skybt for documentation and examples.
 
 ## Known Implementation
 Github repo: https://gitlab.eclipse.org/eclipse/skybt/skybt
@@ -33,7 +33,7 @@ Coming from the ALM tool the configured test suites can be executed in the used 
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
-tbd
+Automotive software testing requires maintainable, reusable test artifacts that bridge design and execution. SKyBT solves this by enabling keyword-driven test modelling that generates executable test cases without manual implementation, reducing lead time and improving test coverage consistency.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-EST/Generator/BB_IFEX.md
+++ b/BB-EST/Generator/BB_IFEX.md
@@ -43,16 +43,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Python 3, IFEX IDL format knowledge
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Any platform with Python. Generates code/artifacts for multiple target languages.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+Single source of truth for interface definitions. Language and framework agnostic.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
+None. Output can target uProtocol, SOME/IP, DDS, or other frameworks.
 
 
 ## Vehicle API Relevant

--- a/BB-EST/Generator/BB_IFEX.md
+++ b/BB-EST/Generator/BB_IFEX.md
@@ -13,7 +13,7 @@ Generator
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Define vehicle service interfaces in IFEX IDL (Interface Definition Language), then use the IFEX tooling to generate code stubs and skeletons for multiple target languages and frameworks. See https://github.com/COVESA/ifex for documentation and examples.
 
 ## Known Implementation
 https://github.com/COVESA/ifex
@@ -27,6 +27,7 @@ The project is a place to do difficult semantic mapping work. While doing so, it
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Automotive development needs a single source of truth for service interface definitions that can be transformed into multiple target representations, avoiding manual translation errors and ensuring consistency across platforms.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-EST/Requirements/BB_SphinxNeeds.md
+++ b/BB-EST/Requirements/BB_SphinxNeeds.md
@@ -48,18 +48,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Python 3, Sphinx documentation framework, reStructuredText
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Any platform with Python. Integrates into Sphinx doc builds.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Living documentation with traceable requirements. Supports export to ReqIF.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+Sphinx documentation framework
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-EST/Requirements/BB_SphinxNeeds.md
+++ b/BB-EST/Requirements/BB_SphinxNeeds.md
@@ -12,7 +12,9 @@ BB-EST
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Source code: https://github.com/useblocks/sphinx-needs  
+Documentation: https://sphinx-needs.readthedocs.io/  
+Sphinx-Needs extends Sphinx documentation with traceable need-objects (requirements, specs, implementations, tests). Define needs using directives like `.. req::` or `.. spec::`, link them with `links` options, and generate traceability matrices and filter views as part of your docs-as-code workflow.
 
 ## Known Implementation
 https://github.com/useblocks/sphinx-needs
@@ -30,6 +32,7 @@ Sphinx-Needs allows the definition, linking and filtering of class-like need-obj
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Automotive development requires requirements management integrated into developer workflows. Sphinx-Needs enables a docs-as-code approach where requirements, specifications, and traceability live alongside source code in version control, eliminating tool silos and enabling review via standard Git workflows.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-EST/Requirements/BB_openfasttrace.md
+++ b/BB-EST/Requirements/BB_openfasttrace.md
@@ -12,7 +12,9 @@ BB-EST
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Source code: https://github.com/itsallcode/openfasttrace  
+Documentation: https://github.com/itsallcode/openfasttrace/blob/main/doc/user_guide.md  
+OFT traces requirements across specification documents, source code, and tests. Embed requirement IDs (e.g., `req~feature-name~1`) in your artifacts and run OFT to generate traceability reports showing coverage and gaps. Integrates into CI/CD pipelines as a Java CLI tool or Maven plugin.
 
 ## Known Implementation
 https://github.com/itsallcode/openfasttrace
@@ -25,6 +27,7 @@ OpenFastTrace (short OFT) is a requirement tracing suite. Requirement tracing ke
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Safety and security standards (ISO 26262, UNECE R155) require full traceability from requirements through implementation to test. OpenFastTrace automates this tracing in CI/CD, detecting missing implementations and obsolete artifacts without expensive commercial ALM tools.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-EST/Requirements/BB_openfasttrace.md
+++ b/BB-EST/Requirements/BB_openfasttrace.md
@@ -43,18 +43,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Java 11+, Maven or Gradle
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Any platform with JVM. Command-line tool and library.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Traceable requirements engineering. Supports ASPICE and ISO 26262 compliance workflows.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+None. Integrates with CI/CD pipelines.
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-EST/Testing/BB_Autowrx.md
+++ b/BB-EST/Testing/BB_Autowrx.md
@@ -13,7 +13,7 @@ Testing
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Web-based prototyping platform (Digital.auto playground) for designing and validating Vehicle App ideas using the COVESA Vehicle Signal Specification (VSS). Access at https://digitalauto.netlify.app/ or self-host from https://gitlab.eclipse.org/eclipse/autowrx/autowrx.
 
 ## Known Implementation
 https://gitlab.eclipse.org/eclipse/autowrx/autowrx
@@ -26,6 +26,7 @@ Rapid prototyping environment to explore and validate ideas of a Vehicle App,  i
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Rapid prototyping of Vehicle Apps without physical hardware accelerates innovation cycles and allows early validation of app concepts against the vehicle API.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-EST/Testing/BB_Autowrx.md
+++ b/BB-EST/Testing/BB_Autowrx.md
@@ -13,7 +13,7 @@ Testing
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-Web-based prototyping platform (Digital.auto playground) for designing and validating Vehicle App ideas using the COVESA Vehicle Signal Specification (VSS). Access at https://digitalauto.netlify.app/ or self-host from https://gitlab.eclipse.org/eclipse/autowrx/autowrx.
+Web-based prototyping platform (digital.auto playground) for designing and validating Vehicle App ideas using the COVESA Vehicle Signal Specification (VSS). Access at https://digitalauto.netlify.app/ or self-host from https://gitlab.eclipse.org/eclipse/autowrx/autowrx.
 
 ## Known Implementation
 https://gitlab.eclipse.org/eclipse/autowrx/autowrx

--- a/BB-EST/Testing/BB_Central_Data_Service_Playground.md
+++ b/BB-EST/Testing/BB_Central_Data_Service_Playground.md
@@ -13,7 +13,7 @@ Testing
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+The CDSP provides a composable testing environment for vehicle data services. Developers experiment with data-centric architecture patterns (storage, mediation, consent) in isolation or combination. Clone the repo and follow the setup at https://github.com/COVESA/cdsp to run data service scenarios locally.
 
 ## Known Implementation
 https://github.com/COVESA/cdsp
@@ -26,6 +26,7 @@ The Central Data Service Playground (CDSP) is a neutral, open playground for dat
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Data-centric vehicle architectures need a neutral, open environment to prototype and validate data service compositions before productization. CDSP provides this sandbox to accelerate understanding and adoption of COVESA data architecture concepts.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-EST/Testing/BB_Eclipse_OpenDUT.md
+++ b/BB-EST/Testing/BB_Eclipse_OpenDUT.md
@@ -14,7 +14,11 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Documentation: https://opendut.eclipse.dev/
+User Manual: https://opendut.eclipse.dev/book/user-manual/index.html
+Developer Setup: https://opendut.eclipse.dev/book/development/getting-started.html
 
+Components: CARL (central management server), EDGAR (edge agent), LEA (web UI), CLEO (CLI). Uses NetBird/WireGuard for VPN networking between distributed test devices.
 
 ## Known Implementation
 https://github.com/eclipse-opendut/opendut

--- a/BB-EST/Testing/BB_Eclipse_OpenDUT.md
+++ b/BB-EST/Testing/BB_Eclipse_OpenDUT.md
@@ -58,28 +58,20 @@ BB is a composition of other BBs
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
-We expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language 
-
-Linux development environment, 
-Peers & Client: ARM32/64, x86_64
-Server: x86_64
-Programming language: Rust
-Test environment: THEO
+Rust toolchain, Node.js (for LEA web UI), Nix (development environment).
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
-NetBird, Wireguard, TURN Sever, Keycloak, Linux-based OS, Cannelloni for CAN support, telemetry stack (Promtail, Loki, Prometheus, Tempo, Grafana), …
+Linux. NetBird/WireGuard for VPN. Docker/Podman for containerized deployment.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-With respect to Safety, Security,
-Encrypted connections between clients, server and peers
+Distributed, secure (VPN-based networking). Supports both on-premise and cloud hosting.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-Other clusters are needed. FC Security, FC Storage, …
-e.g. If FC Security : Security BBs are  needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work
+Network connectivity between distributed test peers. VPN infrastructure (NetBird).
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-EST/Testing/BB_OpenXilEnv.md
+++ b/BB-EST/Testing/BB_OpenXilEnv.md
@@ -13,7 +13,7 @@ Testing
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+OpenXilEnv provides a Software-in-the-Loop (SIL) environment to run and test embedded ECU software on Windows or Linux without target hardware. It includes parameter management, a scripting interface, and signal stimulation. See https://github.com/eclipse-openxilenv/openxilenv for build instructions and usage examples.
 
 ## Known Implementation
 https://github.com/eclipse-openxilenv/openxilenv
@@ -28,6 +28,7 @@ With a Software In the Loop system it is possible to run and test embedded softw
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Early virtual validation of ECU software without physical hardware accelerates development cycles and reduces costs. OpenXilEnv provides an open-source XIL environment as an alternative to commercial SIL tools, enabling broader access to virtual testing across the industry.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-EST/Testing/BB_SIL-Kit.md
+++ b/BB-EST/Testing/BB_SIL-Kit.md
@@ -54,17 +54,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+C++17 compiler, CMake >= 3.12, Git (for submodules).
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Windows 10/11, Linux (Ubuntu 18.04+). Optional: Doxygen + Sphinx for documentation.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+Performance-focused co-simulation. Thread-safe. Sanitizer-tested (ASan, UBSan, TSan).
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-
+None required. Adapters available for QEMU, virtual CAN, FMU, TAP devices.
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-EST/Testing/BB_SIL-Kit.md
+++ b/BB-EST/Testing/BB_SIL-Kit.md
@@ -13,7 +13,17 @@ Testing
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Documentation: https://vectorgrp.github.io/sil-kit-docs
 
+Build from source:
+```bash
+git submodule update --init --recursive
+mkdir build && cd build
+cmake ..
+cmake --build .
+```
+
+Ecosystem adapters: QEMU, TAP devices, virtual CAN (SocketCAN), Generic Linux IO, FMU Importer, Byte Stream Socket. Supports virtual bus simulation for CAN, Ethernet, FlexRay, and LIN.
 
 ## Known Implementation
 https://github.com/vectorgrp/sil-kit
@@ -28,6 +38,7 @@ For documentation on using the Vector SIL Kit, see the HTML documentation, which
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Software-in-the-Loop testing for automotive requires connecting diverse simulation tools, emulators, and virtual machines into a coherent co-simulation environment. SIL Kit provides an open-source, permissively licensed (MIT) library for this purpose, with adapters for QEMU, virtual CAN, FMUs, and more. This enables distributed, hardware-agnostic SIL testing across CAN, Ethernet, FlexRay, and LIN bus systems without proprietary lock-in.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/1-HWLayer/HardwareAbstraction/Type-1-Hypervisor/XENProject/BB_XENHypervisor.md
+++ b/BB-SC/1-HWLayer/HardwareAbstraction/Type-1-Hypervisor/XENProject/BB_XENHypervisor.md
@@ -16,7 +16,9 @@ HWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Source code: https://github.com/xen-project/xen  
+Documentation: https://wiki.xenproject.org/  
+Deploy the Xen hypervisor on supported hardware to create isolated virtual machines for mixed-criticality workloads. Use dom0 (Linux) for management and domU guests for safety-critical or infotainment domains. Configure via xl toolstack or libvirt.
 
 ## Known Implementation
 https://github.com/xen-project/xen

--- a/BB-SC/1-HWLayer/HardwareAbstraction/Type-1-Hypervisor/XENProject/BB_XENHypervisor.md
+++ b/BB-SC/1-HWLayer/HardwareAbstraction/Type-1-Hypervisor/XENProject/BB_XENHypervisor.md
@@ -64,27 +64,22 @@ optional: XEN tools (.e.g. xl)
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
-
-Tracing support (e.g. LTTng) to perform performance analyses and tests - to evaluate real-time capabilities ->  HAL4SDV project
-Evaluation availability and support for drivers used in the automotive domain - openCAN Stack, ... -> HAL4SDV projeckt
+C compiler, cross-compilation toolchain for target architecture
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
-
-Supported hardware (e.g. hhtps://hcl.xenserver.com/)
-Supported OS (Linux, Windows, MacOS, Zeyphr, ...)
+x86_64, ARM (Cortex-A). Bare-metal Type-1 hypervisor. Requires hardware virtualization support.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-
-Safety (support for mixed criticality VMs on one host) 
+Strong isolation between VMs. Safety certification efforts ongoing. Real-time guest support. 
 Security (support encryption, Identity and Access Managemnt)
 Real-Time (support firm and soft real-time)
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-
+Hardware with virtualization extensions (VT-x/AMD-V or ARM VHE)
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/1-HWLayer/Security/BB_Eclipse_Heimlig.md
+++ b/BB-SC/1-HWLayer/Security/BB_Eclipse_Heimlig.md
@@ -13,7 +13,8 @@ OSLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Source code: https://github.com/eclipse-heimlig/heimlig  
+Heimlg provides an HSM firmware implementation in Rust. Deploy it on a dedicated security core to offer cryptographic services (key generation, encryption, signing, CSPRNG) to application cores without exposing key material. Communicates with clients via a request/response API over shared memory.
 
 ## Known Implementation
 https://github.com/eclipse-heimlig/heimlig
@@ -30,6 +31,7 @@ As an HSM, Heimlig typically runs on dedicated hardware and provides cryptograph
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Automotive ECUs require hardware-backed cryptographic services to protect keys and ensure secure boot, authentication, and encrypted communication. An open source HSM firmware written in memory-safe Rust reduces the attack surface compared to C-based implementations and enables transparent security auditing by the community.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/1-HWLayer/Security/BB_Eclipse_Heimlig.md
+++ b/BB-SC/1-HWLayer/Security/BB_Eclipse_Heimlig.md
@@ -47,18 +47,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Rust toolchain (no_std compatible)
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Embedded targets with HSM/crypto hardware. ARM Cortex-M/R.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Hardware security module abstraction. Suitable for safety-critical crypto operations.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+Hardware Security Module (HSM) or crypto accelerator
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/1-HWLayer/Security/BB_Eclipse_Heimlig.md
+++ b/BB-SC/1-HWLayer/Security/BB_Eclipse_Heimlig.md
@@ -14,7 +14,7 @@ OSLayer
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
 Source code: https://github.com/eclipse-heimlig/heimlig  
-Heimlg provides an HSM firmware implementation in Rust. Deploy it on a dedicated security core to offer cryptographic services (key generation, encryption, signing, CSPRNG) to application cores without exposing key material. Communicates with clients via a request/response API over shared memory.
+Heimlig provides an HSM firmware implementation in Rust. Deploy it on a dedicated security core to offer cryptographic services (key generation, encryption, signing, CSPRNG) to application cores without exposing key material. Communicates with clients via a request/response API over shared memory.
 
 ## Known Implementation
 https://github.com/eclipse-heimlig/heimlig

--- a/BB-SC/2a-OSLayer/Linux/BB_AndroidAutomotive.md
+++ b/BB-SC/2a-OSLayer/Linux/BB_AndroidAutomotive.md
@@ -43,20 +43,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Android SDK/NDK, Android Studio, Java/Kotlin
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
-
-Android Compatibility Definition Document: https://source.android.com/docs/compatibility/cdd
+Automotive-grade hardware with Android Automotive BSP. Google Automotive Services (optional).
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Full infotainment-class OS. App ecosystem. Google services integration available.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+Android BSP from SoC vendor. Google Play Store (optional).
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2a-OSLayer/Linux/BB_AndroidAutomotive.md
+++ b/BB-SC/2a-OSLayer/Linux/BB_AndroidAutomotive.md
@@ -13,7 +13,8 @@ APPLayer, MWLayer, OSLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Documentation: https://source.android.com/docs/automotive  
+Android Automotive OS is built into the vehicle as a standalone infotainment platform. OEMs integrate AAOS into their head units; app developers use the Android Automotive app templates and Car App Library to build media, navigation, and communication apps for the in-vehicle display.
 
 ## Known Implementation
 https://source.android.com/docs/automotive
@@ -26,6 +27,7 @@ Android Automotive OS is an Android-based infotainment system that is built into
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Android Automotive OS leverages the extensive Android ecosystem (apps, developer tools, Google services) to deliver a rich infotainment experience with minimal OEM development effort. It provides a familiar platform for third-party app developers and enables over-the-air updates for in-vehicle applications.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2a-OSLayer/Linux/BB_AutomotiveGradeLinux.md
+++ b/BB-SC/2a-OSLayer/Linux/BB_AutomotiveGradeLinux.md
@@ -13,7 +13,9 @@ APPLayer, MWLayer, OSLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Project website: https://www.automotivelinux.org/  
+Documentation: https://docs.automotivelinux.org/  
+AGL provides a complete Linux distribution for automotive use cases. Build an AGL image using the Yocto-based build system, deploy to supported hardware or QEMU, and develop applications using the AGL application framework.
 
 ## Known Implementation
 https://github.com/orgs/agl-ic-eg/repositories?type=all

--- a/BB-SC/2a-OSLayer/Linux/BB_AutomotiveGradeLinux.md
+++ b/BB-SC/2a-OSLayer/Linux/BB_AutomotiveGradeLinux.md
@@ -60,21 +60,22 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
-Linux Build System
+Yocto/BitBake build system, AGL SDK
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Target: x86_64, ARM (QEMU, Raspberry Pi, Renesas R-Car). Host: Linux build machine.
 
 See supported [Hardware](https://docs.automotivelinux.org/en/master/#02_Hardware_Support/01_Supported_Hardware_Overview/
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Automotive-grade. Linux Foundation collaborative project. De facto industry standard.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+None (full Linux distribution). Integrates various open-source components.
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2a-OSLayer/RTOS/BB_Apache_NuttX.md
+++ b/BB-SC/2a-OSLayer/RTOS/BB_Apache_NuttX.md
@@ -44,18 +44,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+C compiler (GCC/Clang), Make/CMake. POSIX/ANSI-compliant API.
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+8-bit to 64-bit MCUs. ARM, RISC-V, x86, Xtensa, MIPS supported. Minimal RAM footprint.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+POSIX-compliant RTOS. Scalable from 8-bit to 64-bit. Real-time capable.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+None (standalone RTOS)
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2a-OSLayer/RTOS/BB_Apache_NuttX.md
+++ b/BB-SC/2a-OSLayer/RTOS/BB_Apache_NuttX.md
@@ -13,7 +13,9 @@ OSLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Source code: https://github.com/apache/nuttx  
+Documentation: https://nuttx.apache.org/docs/latest/  
+NuttX is configured and built using Kconfig/Make. Select your target board, enable required subsystems (networking, USB, CAN, etc.), and build a firmware image. The POSIX-compliant API allows porting existing Linux/Unix applications with minimal changes.
 
 ## Known Implementation
 https://github.com/apache/nuttx
@@ -26,6 +28,7 @@ Apache NuttX is a real-time operating system (RTOS) with an emphasis on standard
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Automotive sensor and actuator ECUs need a lightweight, real-time OS that scales from 8-bit to 64-bit MCUs while providing POSIX compatibility. NuttX fills this niche with a small footprint, deterministic scheduling, and standard APIs that reduce porting effort and vendor lock-in.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2a-OSLayer/RTOS/BB_Eclipse_OpenBSW.md
+++ b/BB-SC/2a-OSLayer/RTOS/BB_Eclipse_OpenBSW.md
@@ -42,18 +42,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+C/C++ compiler, CMake build system
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Automotive ECU targets (ARM Cortex-R/M). Linux host for development.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Professional embedded quality. Automotive-specific design patterns.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+None (standalone BSW stack)
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2a-OSLayer/RTOS/BB_Eclipse_OpenBSW.md
+++ b/BB-SC/2a-OSLayer/RTOS/BB_Eclipse_OpenBSW.md
@@ -13,7 +13,7 @@ MWLayer, OSLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Use the OpenBSW SDK to build embedded automotive applications. Integrate BSW modules (communication, diagnostics, memory) into your ECU project. See https://github.com/eclipse-openbsw for source and documentation.
 
 ## Known Implementation
 https://github.com/eclipse-openbsw
@@ -26,6 +26,7 @@ Eclipse OpenBSW is an open source SDK to build professional, high quality embedd
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Need for an open-source AUTOSAR-like basic software stack that provides standardized automotive BSW modules (communication, diagnostics, memory management) without proprietary licensing constraints.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2a-OSLayer/RTOS/BB_Eclipse_ThreadX.md
+++ b/BB-SC/2a-OSLayer/RTOS/BB_Eclipse_ThreadX.md
@@ -13,7 +13,8 @@ OSLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Source code and docs: https://github.com/eclipse-threadx/rtos-docs  
+Eclipse ThreadX targets deeply embedded MCU-based systems. Integrate it as the RTOS kernel for battery-powered or flash-constrained automotive ECUs. ThreadX provides preemptive scheduling, memory protection via MODULES, and a certified security stack (EAL4+, FIPS 140-2).
 
 ## Known Implementation
 https://github.com/eclipse-threadx/rtos-docs
@@ -28,6 +29,7 @@ Eclipse ThreadX provides an EAL4+ Common Criteria security certified environment
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Highly constrained automotive MCUs (< 64 KB flash) need an RTOS with minimal footprint, deterministic real-time behavior, and pre-certified security. Eclipse ThreadX provides this with EAL4+ Common Criteria certification and IEC 61508 / ISO 26262 safety qualification support, making it suitable for safety-critical embedded vehicle components.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2a-OSLayer/RTOS/BB_Eclipse_ThreadX.md
+++ b/BB-SC/2a-OSLayer/RTOS/BB_Eclipse_ThreadX.md
@@ -45,18 +45,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+C compiler, IAR/GCC/ARMCC toolchains
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+MCUs with <64KB flash. ARM Cortex-M, RISC-V. Battery-powered devices.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+EAL4+ Common Criteria certified. FIPS 140-2 crypto. TrustZone ARMv8-M support. Safety pre-certified (IEC 61508, IEC 62304).
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+None (standalone RTOS with integrated security stack)
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2a-OSLayer/RTOS/BB_LF_Zephyr.md
+++ b/BB-SC/2a-OSLayer/RTOS/BB_LF_Zephyr.md
@@ -49,18 +49,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Zephyr SDK, west meta-tool, CMake, Python 3.8+, Device Tree Compiler.
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Target: ARM Cortex-M/R/A, x86, RISC-V, Xtensa, ARC, SPARC, MIPS. Host: Linux, macOS, Windows.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Real-time, security-focused. Supports memory protection, stack overflow detection. Suitable for safety-critical applications.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+None (self-contained RTOS). Optional: Bluetooth, networking, USB stacks included.
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2a-OSLayer/RTOS/BB_LF_Zephyr.md
+++ b/BB-SC/2a-OSLayer/RTOS/BB_LF_Zephyr.md
@@ -13,7 +13,12 @@ OSLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Documentation: https://docs.zephyrproject.org/
+Getting Started: https://docs.zephyrproject.org/latest/develop/getting_started/index.html
 
+Zephyr uses the `west` meta-tool for building and flashing. Supports 700+ boards across ARM (Cortex-A/R/M), x86, ARC, RISC-V, Xtensa, SPARC, and MIPS architectures.
+
+Community: Discord (https://chat.zephyrproject.org/), mailing lists, weekly tech talks.
 
 ## Known Implementation
 https://github.com/zephyrproject-rtos
@@ -28,6 +33,7 @@ The Zephyr OS is based on a small-footprint kernel designed for use on resource-
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Resource-constrained automotive ECUs and sensors need a scalable, secure RTOS that supports multiple architectures from a single codebase. Zephyr provides a small-footprint kernel with built-in security features, extensive driver support, and a vibrant open-source community (16k+ stars, 3400+ contributors). Its Linux Foundation governance and Apache 2.0 license make it suitable for commercial automotive deployments across diverse hardware platforms.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2a-OSLayer/RTOS/BB_seL4.md
+++ b/BB-SC/2a-OSLayer/RTOS/BB_seL4.md
@@ -13,7 +13,13 @@ OSLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Documentation: https://docs.sel4.systems/
+Tutorials: https://docs.sel4.systems/Tutorials
+API Reference: https://docs.sel4.systems/projects/sel4/api-doc.html
 
+seL4 is typically used as part of a larger build system. Hardware support includes ARM (Cortex-A), x86_64, and RISC-V platforms. The project provides formal verification proofs of correctness for selected configurations.
+
+Community: Discourse forum (https://sel4.discourse.group/), Mattermost chat, mailing lists.
 
 ## Known Implementation
 https://github.com/seL4
@@ -28,6 +34,7 @@ seL4 is grounded in research breakthroughs across multiple science disciplines. 
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Safety-critical automotive systems require a microkernel with formally verified correctness and security guarantees. seL4 is the world's most highly assured OS kernel, with machine-checked proofs of functional correctness, integrity enforcement, and confidentiality. This makes it uniquely suitable as a foundation for mixed-criticality automotive systems where safety-critical and non-critical functions must be isolated with mathematical guarantees.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2a-OSLayer/RTOS/BB_seL4.md
+++ b/BB-SC/2a-OSLayer/RTOS/BB_seL4.md
@@ -50,18 +50,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+C compiler (cross-compilation), CMake, Python, Haskell (for formal verification). ARM or x86_64 target.
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+ARM (Cortex-A), x86_64, RISC-V hardware. Typically used as part of a larger build system (seL4 repo tool).
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Formally verified correctness and security (mathematical proof). Highest assurance level for separation kernels. Mixed-criticality support.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+None. Standalone microkernel. User-space frameworks (CAmkES, seL4 Microkit) available separately.
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2a-OSLayer/Stacks/BB_AUTOWARE.md
+++ b/BB-SC/2a-OSLayer/Stacks/BB_AUTOWARE.md
@@ -13,7 +13,11 @@ MWLayer, OSLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Documentation: https://autowarefoundation.github.io/autoware-documentation/main/
+Installation: https://autowarefoundation.github.io/autoware-documentation/main/installation
+Quick Start Demo: https://autowarefoundation.github.io/autoware-documentation/main/demos/
 
+Autoware is built on ROS2 and provides modules for sensing, perception, localization, planning, and control. Community support via Discord (https://discord.gg/Q94UsPvReQ).
 
 ## Known Implementation
 https://github.com/autowarefoundation/autoware
@@ -26,6 +30,7 @@ Autoware is an open-source software stack for self-driving vehicles, built on th
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Developing autonomous driving systems from scratch requires massive investment in perception, planning, and control algorithms. Autoware provides a comprehensive, production-ready open-source stack (11.9k stars, 3.7k forks) that accelerates commercial deployment of autonomous vehicles. Its modular ROS2-based architecture allows organizations to contribute to and benefit from shared innovation rather than duplicating fundamental AD capabilities.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2a-OSLayer/Stacks/BB_AUTOWARE.md
+++ b/BB-SC/2a-OSLayer/Stacks/BB_AUTOWARE.md
@@ -46,19 +46,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+ROS2 (Humble/Iron), C++17 compiler, Python 3, CUDA (for perception), CMake, colcon
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
-ROS
+Ubuntu 22.04, NVIDIA GPU (for perception modules), 32 GB RAM recommended. Docker supported.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Modular AD stack. Not safety-certified. Research and pre-production quality.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+ROS2 framework, NVIDIA CUDA toolkit, sensor drivers (LiDAR, camera)
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2a-OSLayer/Stacks/BB_Eclipse_Leda.md
+++ b/BB-SC/2a-OSLayer/Stacks/BB_Eclipse_Leda.md
@@ -13,7 +13,15 @@ Lifecycle-Management
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Documentation: https://eclipse-leda.github.io/leda/
 
+Quickstart:
+1. Download latest release or build from sources
+2. Run on emulated QEMU devices (x86-64, ARM64) or Raspberry Pi 4
+3. Provision the device
+4. Deploy Vehicle Apps using Eclipse Velocitas templates
+
+Key components: Poky base OS, containerd runtime, Kanto Container Management, Eclipse Kuksa Databroker, Mosquitto MQTT, COVESA VSS.
 
 ## Known Implementation
 https://github.com/eclipse-leda
@@ -26,6 +34,7 @@ Eclipse Leda provides an "SDV distribution" that pulls together individual contr
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Developers and integrators in the SDV ecosystem need a ready-to-use Linux distribution that integrates key Eclipse SDV components (Velocitas, Kuksa, Kanto) into a cohesive system image. Leda provides pre-built Yocto-based quickstart images for learning, showcases, and prototyping the full SDV development-to-deployment lifecycle, including container-based application deployment on constrained embedded devices.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2a-OSLayer/Stacks/BB_Eclipse_Leda.md
+++ b/BB-SC/2a-OSLayer/Stacks/BB_Eclipse_Leda.md
@@ -50,17 +50,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Yocto/BitBake build system, kas configuration tool.
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Target: QEMU (x86_64, ARM64), Raspberry Pi 4. Host: Linux build machine with Docker.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+Integration-focused; not safety-certified but suitable for development and prototyping.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-
+Integrates Eclipse Velocitas, Eclipse Kuksa, Eclipse Kanto, COVESA VSS, Mosquitto MQTT.
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2a-OSLayer/Stacks/BB_Eclipse_Oniro.md
+++ b/BB-SC/2a-OSLayer/Stacks/BB_Eclipse_Oniro.md
@@ -43,18 +43,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+OpenHarmony SDK, DevEco Studio or Eclipse Theia IDE
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+ARM and x86 targets. Supports multiple kernel profiles (Linux, LiteOS, Zephyr).
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Cross-kernel compatibility. European market compliance (GDPR considerations).
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+OpenHarmony base layers
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2a-OSLayer/Stacks/BB_Eclipse_Oniro.md
+++ b/BB-SC/2a-OSLayer/Stacks/BB_Eclipse_Oniro.md
@@ -15,6 +15,7 @@ OSLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Documentation: https://docs.oniroproject.org/. Build Oniro for target devices using its Yocto/BitBake-based build system, develop applications with ReactNative or native APIs across supported kernels (Linux, Zephyr, LiteOS).
 
 ## Known Implementation
 
@@ -28,6 +29,7 @@ Oniro is an open-source, vendor-neutral Operating System (OS) managed by the Ecl
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Need for a unified, vendor-neutral development framework that supports multiple kernels (Linux, Zephyr) and device classes from a single codebase, enabling consistent development across heterogeneous IoT and automotive platforms.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2a-OSLayer/Stacks/BB_Eclipse_S-CORE.md
+++ b/BB-SC/2a-OSLayer/Stacks/BB_Eclipse_S-CORE.md
@@ -13,6 +13,7 @@ MWLayer, OSLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Documentation and getting started guides are available at https://eclipse-score.github.io/score. The project uses Bazel as its build system. Key modules include: LoLa (communication), FEO (fixed execution order), lifecycle (launch/health management), persistency (key-value store), logging, and orchestrator. Each module can be integrated independently or as part of the full S-CORE stack on Linux or QNX targets.
 
 
 ## Known Implementation

--- a/BB-SC/2a-OSLayer/Stacks/BB_Eclipse_S-CORE.md
+++ b/BB-SC/2a-OSLayer/Stacks/BB_Eclipse_S-CORE.md
@@ -43,18 +43,20 @@ BB Eclipse S-CORE_LOLA, BB Eclipse S-CORE_FEO, BB Eclipse_OpenSOVD
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+C++ and Rust toolchains, Bazel build system, QNX or Linux target
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Linux (x86_64, aarch64), QNX (primary automotive target). AutoSD (CentOS Automotive Stream Distribution).
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Safety-critical (ISO 26262 targeted). Real-time capable. Automotive-grade quality processes.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+None (self-contained middleware stack). Integrates above OS layer, below application layer.
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2a-OSLayer/Stacks/BB_HaloOS.md
+++ b/BB-SC/2a-OSLayer/Stacks/BB_HaloOS.md
@@ -42,18 +42,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+C/C++ toolchain, proprietary build system
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+LiAuto vehicle HPCs. Automotive-grade hardware platforms.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Vehicle-level OS for computing, communication, and control. Production-proven in LiAuto vehicles.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+None (standalone vehicle OS platform)
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2a-OSLayer/Stacks/BB_HaloOS.md
+++ b/BB-SC/2a-OSLayer/Stacks/BB_HaloOS.md
@@ -13,7 +13,7 @@ MWLayer, OSLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+HaloOS provides a vehicle-level OS platform with unified APIs for computing, communication, and control. It can be deployed on automotive-grade hardware to serve as the software foundation across vehicle domains (cockpit, ADAS, body control). See https://gitee.com/haloos for source code and integration documentation.
 
 ## Known Implementation
 https://gitee.com/haloos
@@ -26,6 +26,7 @@ LiAuto HaloOS is a vehicle-level operating system independently developed by LiA
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Modern smart vehicles require a unified OS platform that can manage the growing complexity of in-vehicle computing across multiple domains. HaloOS addresses the limitations of traditional closed vehicle systems by providing an open-source, scalable foundation that supports diverse functional requirements (AD, cockpit, body) on a single platform.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2a-OSLayer/Stacks/BB_OpenHarmony.md
+++ b/BB-SC/2a-OSLayer/Stacks/BB_OpenHarmony.md
@@ -42,18 +42,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+OpenHarmony SDK, DevEco Studio, C/C++/JS/TS
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+ARM, x86, RISC-V targets. From IoT devices to smartphones and vehicles.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Distributed capabilities across device types. Multi-kernel support (Linux, LiteOS).
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+None (full-stack OS framework)
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2a-OSLayer/Stacks/BB_OpenHarmony.md
+++ b/BB-SC/2a-OSLayer/Stacks/BB_OpenHarmony.md
@@ -13,7 +13,7 @@ MWLayer, OSLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Documentation: https://www.openharmony.cn/. Develop distributed applications using the ArkUI framework and ArkTS language, deploy across device classes from IoT to mobile to automotive IVI systems.
 
 ## Known Implementation
 https://gitee.com/openharmony
@@ -26,6 +26,7 @@ OpenHarmony is an open-source project incubated and operated by the OpenAtom Fou
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Need for a distributed OS framework supporting seamless deployment across IoT, mobile, and automotive scenarios with unified device discovery, distributed data management, and cross-device task scheduling.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Communication/BB_COVESA_Open1722.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_COVESA_Open1722.md
@@ -14,7 +14,19 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Repository: https://github.com/COVESA/Open1722
 
+Build:
+```bash
+mkdir build && cd build
+cmake ..
+make
+make examples
+```
+
+Supported AVTP formats: AAF (PCM), CRF, CVF (H.264, MJPEG, JPEG2000), RVF, and ACF (CAN v1/v2, CAN-XL, FlexRay, LIN, MOST, GPC, Sensor, Generic Byte Bus). Also supports custom formats including COVESA VSS transport.
+
+Cross-compilation for aarch64 (Raspberry Pi) and Zephyr RTOS ports are available.
 
 ## Known Implementation
 https://github.com/COVESA/Open1722
@@ -27,6 +39,7 @@ Open1722 is an implementation of the IEEE 1722 protocol, for streaming audio/vid
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Automotive Ethernet is replacing legacy bus systems, but existing fieldbus protocols (CAN, LIN, FlexRay) must be tunneled over Ethernet during the transition. IEEE 1722 (AVTP) provides a standardized way to stream audio/video and tunnel fieldbus messages over TSN-capable Ethernet networks. Open1722 provides a platform-independent, BSD-licensed C implementation that enables rapid adoption of this standard in automotive middleware stacks.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Communication/BB_COVESA_Open1722.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_COVESA_Open1722.md
@@ -55,16 +55,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+C compiler, CMake >= 3.20, CMocka (unit tests)
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Linux (primary), Zephyr RTOS (some examples). Cross-compilation for aarch64 supported.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+Platform-independent core library. TSN-capable Ethernet required for time-synchronized formats.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
+FC Communication (Ethernet/TSN network infrastructure)
 
 
 ## Vehicle API Relevant

--- a/BB-SC/2b-MWLayer/Communication/BB_COVESA_VISSR.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_COVESA_VISSR.md
@@ -14,6 +14,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+The reference server is implemented in Go and supports HTTP and WebSocket transports. Clone the repository from https://github.com/COVESA/vissr, build with `go build`, and run the server to expose VSS data via the VISSv2/v3 API. Clients connect using standard HTTP GET/POST or WebSocket for subscriptions and real-time data streaming. See the [COVESA VISS specification](https://covesa.github.io/vehicle-information-service-specification/) for protocol details.
 
 
 ## Known Implementation
@@ -27,6 +28,7 @@ This project provides a reference implementation of the released COVESA VISSv2.0
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Vehicle applications need a standardized way to access vehicle signal data without coupling to specific ECU implementations or proprietary interfaces. VISSR provides a transport-agnostic server implementing the W3C/COVESA VISS standard, enabling uniform access to the vehicle signal tree (VSS) for both in-vehicle and off-board clients.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Communication/BB_COVESA_VISSR.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_COVESA_VISSR.md
@@ -14,7 +14,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-The reference server is implemented in Go and supports HTTP and WebSocket transports. Clone the repository from https://github.com/COVESA/vissr, build with `go build`, and run the server to expose VSS data via the VISSv2/v3 API. Clients connect using standard HTTP GET/POST or WebSocket for subscriptions and real-time data streaming. See the [COVESA VISS specification](https://covesa.github.io/vehicle-information-service-specification/) for protocol details.
+The reference server is implemented in Go and supports HTTP and WebSocket transports. Clone the repository from https://github.com/COVESA/vissr, build with `go build`, and run the server to expose VSS data via the VISSv2/v3 API. Clients connect using standard HTTP GET/POST or WebSocket for subscriptions and real-time data streaming. See the [COVESA VISS specification](https://github.com/COVESA/vehicle-information-service-specification) for protocol details.
 
 
 ## Known Implementation

--- a/BB-SC/2b-MWLayer/Communication/BB_COVESA_VISSR.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_COVESA_VISSR.md
@@ -44,16 +44,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Go programming language, VSS tools
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Linux. HTTP and WebSocket server endpoints.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+Reference implementation for conformance testing, not production-hardened.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
+S-BB/VSS (Vehicle Signal Specification data model)
 
 
 ## Vehicle API Relevant

--- a/BB-SC/2b-MWLayer/Communication/BB_COVESA_uServices.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_COVESA_uServices.md
@@ -44,16 +44,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Protobuf compiler, Maven, JDK 11+
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Any platform with protobuf toolchain. Generated code for Java and C++.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+Interface specification only; no runtime requirements.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
+Eclipse uProtocol (for transport and communication patterns)
 
 
 ## Vehicle API Relevant

--- a/BB-SC/2b-MWLayer/Communication/BB_COVESA_uServices.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_COVESA_uServices.md
@@ -14,6 +14,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Service interfaces are defined as `.proto` files in the repository at https://github.com/COVESA/uservices. Use protobuf code generation (`protoc`) to produce language-specific stubs for Java, C++, Python, or Rust. The generated code provides type-safe client/server interfaces for common vehicle services (e.g., body, propulsion, chassis). Designed to be used together with Eclipse uProtocol as the communication layer.
 
 
 ## Known Implementation
@@ -27,6 +28,7 @@ uServices is a project that contains the definition of common vehicle services. 
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+SOA in vehicles requires standardized service definitions that are independent of the underlying communication middleware. uServices provides a common, protobuf-based catalogue of vehicle service interfaces, enabling interoperability between different OEMs, suppliers, and middleware stacks without re-defining service contracts per project.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Communication/BB_Eclipse_Canought.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_Eclipse_Canought.md
@@ -14,7 +14,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Deploy CANought services (J1939 translator, UDS translator) alongside Eclipse Kanto to bridge CAN bus communication to IP-based systems. See https://github.com/eclipse-canought for setup and configuration.
 
 ## Known Implementation
 https://github.com/eclipse-canought
@@ -27,6 +27,7 @@ Eclipse CANought provides extensions to the Eclipse Kanto project focused on aut
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Legacy CAN communication (J1939, UDS) needs bridging to modern IP-based transport layers and cloud-connected architectures, enabling SDV platforms to interact with existing vehicle networks.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Communication/BB_Eclipse_Canought.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_Eclipse_Canought.md
@@ -43,16 +43,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Go or Rust toolchain (TBD based on project evolution)
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Linux with CAN interface support. Part of Eclipse Kanto ecosystem.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+Secure CAN communication (J1939, UDS translation).
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
+Eclipse Kanto, physical or virtual CAN bus interface
 
 
 ## Vehicle API Relevant

--- a/BB-SC/2b-MWLayer/Communication/BB_Eclipse_KUKSA.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_Eclipse_KUKSA.md
@@ -59,17 +59,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Rust toolchain, Protobuf compiler (protoc), gRPC.
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Linux (x86_64, aarch64, RISC-V). Docker/Podman for containerized deployment. Lightweight (<4 MB binary).
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+Resource-efficient, suitable for embedded vehicle computers. Supports TLS for secure communication.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-
+FC Communication (VSS data model from S-BB/VSS).
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2b-MWLayer/Communication/BB_Eclipse_KUKSA.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_Eclipse_KUKSA.md
@@ -14,7 +14,23 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Documentation: https://eclipse-kuksa.github.io/kuksa-website/
 
+Quick start with Docker:
+```bash
+docker network create kuksa
+docker run -it --rm --name Server --network kuksa ghcr.io/eclipse-kuksa/kuksa-databroker:main --insecure
+```
+
+Interact via CLI:
+```bash
+docker run -it --rm --network kuksa ghcr.io/eclipse-kuksa/kuksa-databroker-cli:main --server Server:55555
+# At the prompt:
+get Vehicle.Speed
+publish Vehicle.Speed 100.34
+```
+
+KUKSA Databroker provides gRPC-based APIs (kuksa.val.v2, kuksa.val.v1) and supports COVESA VISS v2 over WebSocket. Written in Rust, it is lightweight (<4 MB statically compiled).
 
 ## Known Implementation
 https://github.com/eclipse-kuksa
@@ -27,6 +43,7 @@ The open Eclipse KUKSA™ project aims to provide shared building blocks for the
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Vehicle applications need a uniform way to access sensor and actuator data regardless of the underlying hardware and ECU communication protocols (CAN, SOME/IP, etc.). KUKSA Databroker provides a resource-efficient, in-vehicle implementation of the COVESA Vehicle Signal Specification (VSS) tree that abstracts low-level vehicle interfaces into a high-level gRPC API. This enables application developers to focus on functionality rather than vehicle-specific integration, and allows the same application code to run across different vehicle platforms.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Communication/BB_Eclipse_S-CORE_LOLA.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_Eclipse_S-CORE_LOLA.md
@@ -13,6 +13,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Source code and build instructions are at https://github.com/eclipse-score/communication. LoLa uses shared-memory based IPC with lock-free data structures for zero-copy communication between processes. Built with Bazel as part of the S-CORE project. Provides C++ and Rust APIs for publishers/subscribers with deterministic timing guarantees suitable for ADAS pipelines. See the S-CORE documentation at https://eclipse-score.github.io/score for integration guidance.
 
 
 ## Known Implementation
@@ -26,6 +27,7 @@ Low-Latency communication middleware for ADAS use cases.
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+ADAS and autonomous driving functions require ultra-low-latency, deterministic inter-process communication that can meet safety requirements (ISO 26262). Traditional IPC mechanisms (sockets, D-Bus) introduce unacceptable latency and non-determinism. LoLa provides lock-free, shared-memory communication designed specifically for safety-critical real-time data exchange on HPC ECUs.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Communication/BB_Eclipse_S-CORE_LOLA.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_Eclipse_S-CORE_LOLA.md
@@ -43,18 +43,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+C++ compiler, Bazel build system
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Linux (x86_64, aarch64), QNX. Shared memory required.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Lock-free, low-latency. Designed for ADAS real-time requirements. Safety-critical (ISO 26262 targeted).
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+Eclipse S-CORE base libraries
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2b-MWLayer/Communication/BB_Eclipse_Zenoh.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_Eclipse_Zenoh.md
@@ -14,7 +14,22 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Documentation and getting started: https://zenoh.io/docs/getting-started/installation/
 
+Basic pub/sub example (Rust):
+```bash
+cargo run --example z_sub
+cargo run --example z_pub
+```
+
+Query/Reply pattern:
+```bash
+cargo run --example z_queryable
+cargo run --example z_get
+```
+
+Language bindings available for: Rust, C, C++, Python, Kotlin, Java, TypeScript.
+A pure-C implementation (zenoh-pico) is available for resource-constrained devices.
 
 ## Known Implementation
 https://github.com/eclipse-zenoh/zenoh
@@ -29,6 +44,7 @@ Zenoh (pronounce /zeno/) unifies data in motion, data at rest and computations. 
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Modern vehicle architectures require communication across heterogeneous environments — from microcontrollers at the edge, through in-vehicle HPCs, to cloud backends. Zenoh provides a single, unified protocol that handles pub/sub, distributed storage, and queries with extremely low overhead and latency. Its ability to run on constrained devices (via zenoh-pico) as well as powerful servers, combined with support for geo-distributed storage and computation, makes it suitable for end-to-end SDV communication without requiring multiple disparate middleware stacks.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Communication/BB_Eclipse_Zenoh.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_Eclipse_Zenoh.md
@@ -60,17 +60,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Rust toolchain (stable >= 1.75), Cargo build system.
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Linux, macOS, or Windows. Optional: Docker for containerized deployment. Minimal resource requirements.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+Low-latency, high-throughput. Designed for constrained and powerful devices alike.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-
+None required, but can integrate with FC Communication (DDS, MQTT bridging).
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2b-MWLayer/Communication/BB_Eclipse_eCAL.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_Eclipse_eCAL.md
@@ -69,17 +69,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+C++14 compiler, CMake >= 3.13, Protobuf (optional).
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Linux (Ubuntu 18.04+), Windows 10/11, macOS (experimental), QNX (experimental). Shared memory for local transport, UDP/TCP for network.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+High throughput (1-20 GB/s), brokerless architecture. No hard real-time guarantees.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-
+None required. Optional integration with ROS2 (rmw_ecal).
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2b-MWLayer/Communication/BB_Eclipse_eCAL.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_Eclipse_eCAL.md
@@ -14,7 +14,33 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Documentation: https://eclipse-ecal.github.io/ecal/
 
+Installation (Ubuntu):
+```bash
+sudo add-apt-repository ppa:ecal/ecal-latest
+sudo apt-get update
+sudo apt-get install ecal
+```
+
+Minimal publisher example (C++):
+```cpp
+#include <ecal/ecal.h>
+#include <ecal/msg/string/publisher.h>
+#include <thread>
+
+int main(int argc, char** argv) {
+  eCAL::Initialize(argc, argv, "Hello World Publisher");
+  eCAL::string::CPublisher publisher("hello_world_topic");
+  while (eCAL::Ok()) {
+    publisher.Send("Hello World");
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  }
+  eCAL::Finalize();
+}
+```
+
+Language bindings: C++, C, Python, C#, Rust. Integrations available for ROS2 (rmw_ecal), Matlab Simulink, and Foxglove.
 
 ## Known Implementation
 https://github.com/eclipse-ecal/ecal
@@ -27,6 +53,7 @@ The enhanced Communication Abstraction Layer (eCAL) is a middleware that enables
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+eCAL solves the problem of efficient, high-performance data exchange between distributed software components in automotive and robotics applications. It achieves 1–20 GB/s throughput (depending on payload) by automatically selecting the best transport (shared memory for local, UDP/TCP for network). Its brokerless, zero-configuration architecture simplifies deployment, while built-in tools for recording (HDF5), replay, and monitoring enable efficient development and testing workflows without additional infrastructure.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Communication/BB_Eclipse_iceoryx2.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_Eclipse_iceoryx2.md
@@ -58,17 +58,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Rust toolchain (MSRV 1.89), C++ compiler (for C++ bindings), CMake or Bazel build system.
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Linux (x86_64, aarch64, 32-bit), Windows, macOS, FreeBSD, QNX 7.1/8.0. Shared memory support required.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+Zero-copy, lock-free IPC. Designed for real-time and safety-critical systems. ISO 26262 relevant.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-
+None. Standalone IPC middleware.
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2b-MWLayer/Communication/BB_Eclipse_iceoryx2.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_Eclipse_iceoryx2.md
@@ -14,7 +14,17 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Documentation: https://ekxide.github.io/iceoryx2-book
 
+API References: Rust (https://docs.rs/iceoryx2/latest/iceoryx2/), C++, C, Python.
+
+Examples are available at https://github.com/eclipse-iceoryx/iceoryx2/tree/main/examples covering pub/sub, request/response, and event patterns.
+
+Supported platforms: Linux (x86_64, aarch64, 32-bit), Windows, macOS, FreeBSD, QNX 7.1/8.0, with proof-of-concept for Android, VxWorks, and bare-metal (no_std).
+
+Language bindings: Rust (primary), C++, C, Python, C#.
+
+Yocto recipes available at: https://github.com/eclipse-iceoryx/meta-iceoryx2
 
 ## Known Implementation
 https://github.com/eclipse-iceoryx/iceoryx2

--- a/BB-SC/2b-MWLayer/Communication/BB_Eclipse_uProtocol.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_Eclipse_uProtocol.md
@@ -44,17 +44,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Language-specific SDKs: Rust, Java (JDK 11+), C++, Python. Protobuf for message definitions.
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Any platform supporting the target language runtime. Transport-agnostic (runs over zenoh, SOME/IP, MQTT, Binder).
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+Transport-agnostic design ensures consistent behavior across different communication backends.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-
+Requires a transport layer implementation (e.g., BB-SC Zenoh, vSomeIP, or MQTT).
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2b-MWLayer/Communication/BB_Eclipse_uProtocol.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_Eclipse_uProtocol.md
@@ -14,6 +14,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Language-specific SDKs are available: [up-rust](https://github.com/eclipse-uprotocol/up-rust), [up-java](https://github.com/eclipse-uprotocol/up-java), [up-cpp](https://github.com/eclipse-uprotocol/up-cpp), and [up-python](https://github.com/eclipse-uprotocol/up-python). The protocol specification is maintained at https://github.com/eclipse-uprotocol/up-spec. Transport layer implementations exist for zenoh, SOME/IP, MQTT, and Android Binder, allowing deployment across heterogeneous communication stacks. Developers define services using protobuf and interact via the uP-L1/L2/L3 API layers.
 
 
 ## Known Implementation

--- a/BB-SC/2b-MWLayer/Communication/BB_OpenSOVD.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_OpenSOVD.md
@@ -14,6 +14,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+The implementation is available at https://github.com/eclipse-opensovd/opensovd. OpenSOVD exposes a RESTful Web API conforming to ISO 17978 (SOVD), enabling diagnostic clients to access vehicle data, run diagnostic routines, and manage fault memory over HTTP/REST. Integrate by deploying the SOVD gateway alongside existing diagnostic infrastructure and connecting diagnostic tool clients via the standardized API endpoints.
 
 
 ## Known Implementation
@@ -29,6 +30,7 @@ Eclipse OpenSOVD provides an open source implementation of the Service-Oriented 
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Traditional vehicle diagnostics (UDS/ODX) are tightly coupled to transport protocols and require specialized tooling. SOVD (ISO 17978) modernizes diagnostics with a service-oriented, web-based approach enabling remote and in-vehicle diagnostics via standard HTTP APIs. OpenSOVD provides the open-source reference stack to accelerate adoption and ensure cross-vendor interoperability.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Communication/BB_XCPlite.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_XCPlite.md
@@ -14,7 +14,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Integrate XCPlite into your ECU application for XCP-on-Ethernet measurement and calibration. See https://github.com/vectorgrp/XCPlite for integration examples and API documentation.
 
 ## Known Implementation
 https://github.com/vectorgrp/XCPlite
@@ -31,6 +31,7 @@ It provides real time signal oriented data acquisition (measurement, logging) an
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+ECU measurement and calibration needs a lightweight, open-source XCP implementation that enables real-time signal acquisition and parameter tuning without heavy commercial tool dependencies.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Communication/BB_XCPlite.md
+++ b/BB-SC/2b-MWLayer/Communication/BB_XCPlite.md
@@ -47,16 +47,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+C compiler
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Linux, Windows. Ethernet interface for XCP-on-Ethernet transport.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+Lightweight implementation for measurement and calibration. Not safety-critical.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
+None. Standalone XCP implementation.
 
 
 ## Vehicle API Relevant

--- a/BB-SC/2b-MWLayer/Communication/RTPS-Types/DustDDS/BB_DustDDS.md
+++ b/BB-SC/2b-MWLayer/Communication/RTPS-Types/DustDDS/BB_DustDDS.md
@@ -15,6 +15,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Dust DDS is used as a Rust library (crate). Define DDS topics with Rust structs, create a DomainParticipant, and use publishers/subscribers to exchange data. Being a native Rust implementation, it integrates directly into Rust-based automotive middleware stacks. See https://github.com/s2e-systems/dust-dds for API documentation and examples.
 
 ## Known Implementation
 
@@ -28,6 +29,7 @@ Dust DDS is a native Rust implementation of the Data Distribution Service (DDS) 
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Rust-based SDV middleware stacks need a memory-safe, performant DDS implementation without C/C++ FFI overhead. Dust DDS provides a native Rust DDS/RTPS stack, enabling safe concurrency and interoperability with other DDS implementations while leveraging Rust's compile-time safety guarantees.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Communication/RTPS-Types/FastDDS/BB_FastDDS.md
+++ b/BB-SC/2b-MWLayer/Communication/RTPS-Types/FastDDS/BB_FastDDS.md
@@ -14,7 +14,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Documentation: https://fast-dds.docs.eprosima.com/. Use the DDS/RTPS API for publish/subscribe messaging with configurable QoS, discovery, and transport. Default ROS 2 middleware implementation.
 
 ## Known Implementation
 https://github.com/eProsima/Fast-DDS
@@ -27,6 +27,7 @@ eprosima Fast DDS is a C++ implementation of the DDS (Data Distribution Service)
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Default ROS 2 middleware with proven track record in automotive and robotics. Provides a feature-rich, standards-compliant DDS implementation with direct RTPS protocol access for advanced use cases.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Communication/RTPS-Types/FastDDS/BB_FastDDS.md
+++ b/BB-SC/2b-MWLayer/Communication/RTPS-Types/FastDDS/BB_FastDDS.md
@@ -43,6 +43,7 @@ OS/Runtime Envirnoment
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+C++11 compiler, CMake, Asio, TinyXML2
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
@@ -56,6 +57,7 @@ See [supported Platforms](https://github.com/eProsima/Fast-DDS/blob/master/PLATF
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
+None required. Optional: ROS2 integration.
 
 
 ## Vehicle API Relevant

--- a/BB-SC/2b-MWLayer/Communication/RTPS-Types/OpenDDS/BB_OpenDDS.md
+++ b/BB-SC/2b-MWLayer/Communication/RTPS-Types/OpenDDS/BB_OpenDDS.md
@@ -14,7 +14,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+OpenDDS uses IDL files to define data types and topics. Applications create DomainParticipants, Publishers/Subscribers, and DataWriters/DataReaders to exchange data over configurable transports (TCP, UDP, RTPS, shared memory). See the Developer's Guide at https://opendds.readthedocs.io for detailed API usage, examples, and configuration options.
 
 ## Known Implementation
 https://github.com/OpenDDS/OpenDDS
@@ -27,6 +27,7 @@ OpenDDS is an open-source C++ implementation of the Object Management Group's sp
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Distributed automotive systems require reliable, real-time publish-subscribe communication with QoS guarantees. OpenDDS provides a mature, standards-compliant DDS implementation that supports interoperability via RTPS, making it suitable for in-vehicle and cross-domain communication where multiple DDS vendors must coexist.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Communication/RTPS-Types/cycloneDDS/BB_cycloneDDS.md
+++ b/BB-SC/2b-MWLayer/Communication/RTPS-Types/cycloneDDS/BB_cycloneDDS.md
@@ -54,6 +54,7 @@ OS/Runtime Envirnoment
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+C compiler, CMake
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
@@ -74,6 +75,7 @@ QOS
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
+None required. Optional: ROS2 integration via rmw_cyclonedds.
 
 
 ## Vehicle API Relevant

--- a/BB-SC/2b-MWLayer/Communication/RTPS-Types/cycloneDDS/BB_cycloneDDS.md
+++ b/BB-SC/2b-MWLayer/Communication/RTPS-Types/cycloneDDS/BB_cycloneDDS.md
@@ -14,7 +14,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Documentation: https://cyclonedds.io/docs/. Use the DDS C/C++ API for publish/subscribe communication. Supports zero-configuration discovery, QoS policies, and shared-memory transport via Eclipse Iceoryx integration.
 
 ## Known Implementation
 https://github.com/eclipse-cyclonedds/cyclonedds
@@ -27,6 +27,7 @@ Eclipse Cyclone DDS is a very performant and robust open-source implementation o
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Automotive and robotics middleware needs a certifiable, high-performance DDS implementation with deterministic behavior, security support, and ROS 2 tier-1 integration for real-time publish/subscribe communication.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Communication/RTPS-Types/embeddedRTPS/BB_Constraint_DDS_embeddedRTPS.md
+++ b/BB-SC/2b-MWLayer/Communication/RTPS-Types/embeddedRTPS/BB_Constraint_DDS_embeddedRTPS.md
@@ -14,7 +14,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+embeddedRTPS runs on FreeRTOS with lwIP. Configure publishers/subscribers at compile time to avoid dynamic memory allocation at runtime. A reference implementation for STM32 is available at https://github.com/embedded-software-laboratory/embeddedRTPS-STM32. The stack integrates as a first-class DDS participant into ROS 2 or AUTOSAR Adaptive networks.
 
 ## Known Implementation
 Github repo: <https://github.com/embedded-software-laboratory/embeddedRTPS>

--- a/BB-SC/2b-MWLayer/Communication/RTPS-Types/vSomeIP/BB_vSomeIP.md
+++ b/BB-SC/2b-MWLayer/Communication/RTPS-Types/vSomeIP/BB_vSomeIP.md
@@ -55,18 +55,22 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+C++14 compiler, CMake, Boost libraries
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Linux (primary), Android, QNX. IP network connectivity.
 
 [see COVESA Github repo](https://github.com/COVESA/vsomeip)
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+AUTOSAR-compatible wire format. Production-grade automotive middleware.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
+None. Standalone SOME/IP implementation.
 
 
 ## Vehicle API Relevant

--- a/BB-SC/2b-MWLayer/Communication/RTPS-Types/vSomeIP/BB_vSomeIP.md
+++ b/BB-SC/2b-MWLayer/Communication/RTPS-Types/vSomeIP/BB_vSomeIP.md
@@ -16,7 +16,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Documentation and source: https://github.com/COVESA/vsomeip. Configure services via JSON, use the vsomeip API for service discovery, request/response, and event notification patterns. See the vsomeip wiki for a 10-minute getting started guide.
 
 ## Known Implementation
 [vSomeIP](https://github.com/COVESA/vsomeip)

--- a/BB-SC/2b-MWLayer/Deployment-Management/BB_Eclipse_Ankaios.md
+++ b/BB-SC/2b-MWLayer/Deployment-Management/BB_Eclipse_Ankaios.md
@@ -14,7 +14,11 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Documentation: https://eclipse-ankaios.github.io/ankaios/
 
+Ankaios uses a declarative state model: you define the desired set of workloads in a manifest, and the system ensures convergence. It supports Podman containers as first-class runtime, with extensibility for other runtimes and native applications.
+
+The `ank` CLI provides commands to manage workloads, query state, and apply configurations.
 
 ## Known Implementation
 https://github.com/eclipse-ankaios/ankaios
@@ -27,6 +31,7 @@ Eclipse Ankaios provides workload and container orchestration for automotive Hig
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Automotive HPCs require workload orchestration that is lightweight, deterministic, and suitable for regulated environments. Traditional cloud orchestration tools (e.g., Kubernetes) are too resource-heavy and not designed for automotive safety and real-time constraints. Ankaios provides a slim, purpose-built solution that manages containerized applications across multiple nodes and VMs with a single API, independent of existing communication frameworks like SOME/IP, DDS, or REST.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Deployment-Management/BB_Eclipse_Ankaios.md
+++ b/BB-SC/2b-MWLayer/Deployment-Management/BB_Eclipse_Ankaios.md
@@ -47,17 +47,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Rust toolchain, Protobuf compiler.
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Linux (x86_64, aarch64). Requires container runtime (Podman recommended). Server-agent architecture.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+Lightweight, deterministic. Designed for automotive real-time constraints. Independent of SOME/IP, DDS, REST.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-
+Container runtime (Podman/containerd). Independent of FC Communication.
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2b-MWLayer/Deployment-Management/BB_Eclipse_SymphonyAgents.md
+++ b/BB-SC/2b-MWLayer/Deployment-Management/BB_Eclipse_SymphonyAgents.md
@@ -43,18 +43,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Go programming language
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Kubernetes/edge environments. Cross-platform agent deployment.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Vendor-agnostic orchestration. Integrates existing systems without modification.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+Kubernetes (optional), edge device connectivity
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2b-MWLayer/Deployment-Management/BB_Eclipse_SymphonyAgents.md
+++ b/BB-SC/2b-MWLayer/Deployment-Management/BB_Eclipse_SymphonyAgents.md
@@ -13,7 +13,8 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Documentation and getting started: https://eclipse-symphony.github.io/symphony-website/  
+Symphony provides a unified orchestration platform for managing workloads across heterogeneous devices. Deploy Symphony agents on target devices to enable declarative, vendor-agnostic workload deployment and lifecycle management from a central control plane.
 
 ## Known Implementation
 https://eclipse-symphony.github.io/symphony-website/
@@ -26,7 +27,7 @@ Project Symphony is an Eclipse Foundation open-source orchestration platform tha
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
-TBD
+Vehicle fleets consist of heterogeneous hardware and software stacks from multiple vendors. A unified orchestration platform is needed to manage workload deployment, updates, and lifecycle across diverse edge devices without requiring modifications to existing systems or vendor-specific tooling.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Diagnostics/BB_Eclipse_OpenSOVD.md
+++ b/BB-SC/2b-MWLayer/Diagnostics/BB_Eclipse_OpenSOVD.md
@@ -14,7 +14,8 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Source code and documentation: https://github.com/eclipse-opensovd/opensovd  
+OpenSOVD provides a standards-compliant SOVD (ISO 17978) implementation. Deploy it as the diagnostics middleware to expose vehicle diagnostic data over RESTful service-oriented interfaces to diagnostic tools and cloud backends.
 
 ## Known Implementation
 https://github.com/eclipse-opensovd/opensovd
@@ -27,6 +28,7 @@ Eclipse OpenSOVD provides an open source implementation of the Service-Oriented 
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+The automotive industry is transitioning from legacy UDS-based diagnostics to service-oriented architectures. An open source SOVD (ISO 17978) implementation ensures interoperability across OEMs and tool vendors, reduces proprietary lock-in, and accelerates adoption of modern vehicle diagnostics.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Diagnostics/BB_Eclipse_OpenSOVD.md
+++ b/BB-SC/2b-MWLayer/Diagnostics/BB_Eclipse_OpenSOVD.md
@@ -44,16 +44,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+C++ or Rust (TBD based on project evolution), REST API knowledge
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Linux-based vehicle HPCs. HTTP/REST endpoint.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+Standards-compliant (ISO 17978). Secure diagnostic access over service-oriented architectures.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
+FC Communication (HTTP/REST transport), vehicle diagnostic data sources
 
 
 ## Vehicle API Relevant

--- a/BB-SC/2b-MWLayer/Diagnostics/BB_Eclipse_OpenSOVD.md
+++ b/BB-SC/2b-MWLayer/Diagnostics/BB_Eclipse_OpenSOVD.md
@@ -44,7 +44,7 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
-C++ or Rust (TBD based on project evolution), REST API knowledge
+Rust toolchain, REST API knowledge
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->

--- a/BB-SC/2b-MWLayer/Diagnostics/BB_Eclipse_S-CORE_logging.md
+++ b/BB-SC/2b-MWLayer/Diagnostics/BB_Eclipse_S-CORE_logging.md
@@ -15,6 +15,8 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Source code and documentation: https://github.com/eclipse-score/logging  
+The S-CORE logging daemon collects, stores, and forwards log messages from safety-critical vehicle software components. Integrate it as the central logging service for systems built on the S-CORE platform.
 
 ## Known Implementation
 
@@ -30,6 +32,7 @@ Logging service for S-CORE systems
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Safety-critical automotive systems require a logging service that is designed for deterministic behavior, minimal resource usage, and traceability. General-purpose logging frameworks (e.g., journald) lack the safety considerations and automotive-specific constraints needed for ISO 26262 qualified systems.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_BlueChi.md
+++ b/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_BlueChi.md
@@ -13,7 +13,11 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Documentation: https://bluechi.readthedocs.io/en/latest/
 
+BlueChi extends systemd's D-Bus API for multi-node use cases. It uses a controller-agent architecture where one BlueChi controller manages multiple agents (one per node). Services are controlled via D-Bus commands or the `bluechictl` CLI.
+
+It can also control containerized applications using Podman with quadlet-generated systemd service units.
 
 ## Known Implementation
 https://github.com/eclipse-bluechi/bluechi
@@ -26,6 +30,7 @@ Eclipse BlueChi™ is a systemd service controller intended for multi-node envir
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+In multi-node automotive edge environments, services must be reliably controlled across different devices while complying with functional safety regulations. Traditional orchestration tools are not designed for these regulated ecosystems. BlueChi leverages the well-proven systemd service manager and extends it to multi-node scenarios with a predefined topology, providing deterministic service lifecycle management suitable for safety-critical domains like transportation.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_BlueChi.md
+++ b/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_BlueChi.md
@@ -46,19 +46,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+C compiler (GCC/Clang), Meson build system, D-Bus libraries.
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
-systemd
+Linux with systemd. CentOS Stream 9/10, Fedora. RPM packages available via COPR.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Functional safety focus. Deterministic service lifecycle management for regulated environments.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+Requires systemd on all managed nodes. Optional: Podman for containerized workloads.
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_Muto.md
+++ b/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_Muto.md
@@ -13,6 +13,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Documentation and tutorials are available at https://eclipse-muto.github.io/docs/. Muto integrates with ROS2 for in-vehicle robotics stacks and provides cloud connectivity for remote orchestration. Developers define adaptive stack configurations that can be dynamically updated at runtime. The stack composer manages ROS2 launch files and runtime parameters based on context-aware policies.
 
 
 ## Known Implementation
@@ -26,6 +27,7 @@ Muto is a context aware software solution to address some of the runtime adaptiv
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Autonomous and software-defined vehicles require runtime adaptability — the ability to dynamically reconfigure software stacks based on context (e.g., driving mode, environment, OTA updates). Muto addresses this by providing a framework for context-aware stack composition and cloud-managed lifecycle, reducing the complexity of managing heterogeneous ROS2-based deployments.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_Muto.md
+++ b/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_Muto.md
@@ -43,19 +43,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+ROS2 development environment, Python 3
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
-ROS
+Linux with ROS2. Cloud connectivity (MQTT) for remote management.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Context-aware adaptivity. Cloud-connected runtime modification.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+ROS2 framework, MQTT broker for cloud connectivity
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_PullPiriPackageServiceOrchestrator.md
+++ b/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_PullPiriPackageServiceOrchestrator.md
@@ -13,7 +13,8 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Documentation and source code: https://github.com/eclipse-pullpiri/pullpiri  
+PULLPIRI provides a service orchestrator framework for in-vehicle use. Integrate it as the orchestration layer managing lifecycle and activation of vehicle services based on context-aware policies.
 
 ## Known Implementation
 https://github.com/eclipse-pullpiri/pullpiri
@@ -26,7 +27,7 @@ The main goal of PULLPIRI project is to develop an efficient vehicle service orc
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
-TBD
+Modern vehicles require cloud-native service orchestration to manage complex, context-dependent in-vehicle applications. PULLPIRI enables short development cycles for deploying vehicle scenarios by providing a standardized orchestration framework that activates services based on vehicle status, environment, and connected device contexts.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_S-CORE_FEO.md
+++ b/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_S-CORE_FEO.md
@@ -13,6 +13,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Source code and documentation at https://github.com/eclipse-score/feo. FEO provides a framework for defining deterministic execution schedules where task execution order is statically configured at design time. Built with Bazel as part of S-CORE. Developers define execution graphs specifying task dependencies and timing constraints; the FEO runtime ensures tasks execute in the prescribed order within each cycle. See https://eclipse-score.github.io/score for integration with other S-CORE modules.
 
 
 ## Known Implementation
@@ -26,6 +27,7 @@ Fixed-Execution-Order management framework by the Eclipse S-CORE project
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Safety-critical automotive functions (ADAS, chassis control) require deterministic and reproducible execution timing. General-purpose OS schedulers cannot guarantee fixed execution order across multiple cooperating processes. FEO fills this gap by providing a framework that enforces statically-defined execution sequences, enabling ISO 26262 compliant timing behavior on HPC platforms.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_S-CORE_FEO.md
+++ b/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_S-CORE_FEO.md
@@ -43,18 +43,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Rust toolchain, Bazel build system
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Linux (x86_64, aarch64), QNX.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Deterministic execution order. Safety-critical (ISO 26262 targeted).
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+Eclipse S-CORE base libraries
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_S-CORE_kyron.md
+++ b/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_S-CORE_kyron.md
@@ -15,6 +15,8 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Source code and documentation: https://github.com/eclipse-score/kyron  
+Kyron is a safe async runtime for Rust designed for safety-critical systems. Use it as the execution backend for asynchronous task scheduling in automotive Rust applications where ISO 26262 compliance is required.
 
 ## Known Implementation
 
@@ -30,6 +32,7 @@ Repository for safe async runtime called kyron for Rust
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Safety-critical automotive software written in Rust needs an async runtime that guarantees deterministic behavior and is designed for ISO 26262 qualification. General-purpose runtimes like tokio are not suitable for safety-relevant contexts due to their complexity and lack of safety analysis.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_S-CORE_lifecycle.md
+++ b/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_S-CORE_lifecycle.md
@@ -64,18 +64,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+C++ compiler, Rust toolchain (for bindings), Bazel build system
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Linux (x86_64, aarch64), QNX.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Safety-critical lifecycle management. Health monitoring for system reliability.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+Eclipse S-CORE base libraries
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_S-CORE_lifecycle.md
+++ b/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_S-CORE_lifecycle.md
@@ -15,6 +15,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Source code and examples at https://github.com/eclipse-score/lifecycle. The Launch Manager handles ordered startup/shutdown of process groups based on dependency configurations. The Health Monitor provides alive, deadline, and logical supervision. Implemented in C++ with Rust bindings available. Supports Linux, QNX7, and QNX8. See the `demo/` folder for usage examples and https://eclipse-score.github.io/score for integration guidance.
 
 ## Known Implementation
 
@@ -48,6 +49,7 @@ High level functionality provided by Lifecycle:
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+HPC-based automotive systems run many interdependent processes that must start in a defined order, be monitored for health, and recover from failures automatically. Unlike general-purpose init systems (systemd), this lifecycle manager is designed for safety-critical automotive constraints — supporting QNX RTOS, providing configurable supervision, and integrating with external watchdogs for ISO 26262 compliance.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_S-CORE_orchestration.md
+++ b/BB-SC/2b-MWLayer/Execution-Management/BB_Eclipse_S-CORE_orchestration.md
@@ -15,6 +15,8 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Source code and documentation: https://github.com/eclipse-score/orchestrator  
+Define cause-effect chains declaratively to orchestrate component interactions. The orchestrator schedules and coordinates execution of software components according to their data dependencies and timing constraints.
 
 ## Known Implementation
 
@@ -30,6 +32,7 @@ Orchestration as declarative model to define cause-effect chains of actions
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Automotive systems require deterministic orchestration of component interactions to ensure correct execution order and timing. A declarative model for cause-effect chains enables safety-qualifiable scheduling of complex software architectures without hard-coding execution sequences.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Security/BB_quantumSAR.md
+++ b/BB-SC/2b-MWLayer/Security/BB_quantumSAR.md
@@ -13,7 +13,8 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Source code: https://github.com/iavofficial/IAV_quantumSAR  
+quantumSAR provides post-quantum cryptographic algorithms as an AUTOSAR Classic Cryptodriver. Integrate it into your AUTOSAR BSW stack to replace or supplement classical crypto algorithms with quantum-resistant alternatives (ML-KEM, ML-DSA, SLH-DSA). Requires an AUTOSAR Classic environment and compatible automotive MCU.
 
 ## Known Implementation
 https://github.com/iavofficial/IAV_quantumSAR
@@ -26,6 +27,7 @@ IAV quantumSAR is planned as an AUTOSAR Cryptodriver with a collection of post-q
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Quantum computers threaten current automotive cryptographic algorithms. Vehicles have long lifecycles (15+ years), so post-quantum cryptography must be integrated now to protect against future "harvest now, decrypt later" attacks. quantumSAR provides NIST-standardized PQC algorithms optimized for resource-constrained automotive microcontrollers.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Security/BB_quantumSAR.md
+++ b/BB-SC/2b-MWLayer/Security/BB_quantumSAR.md
@@ -43,18 +43,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+C compiler for AUTOSAR Classic targets, AUTOSAR development tools
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Automotive microcontrollers with AUTOSAR Classic environment.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Post-quantum security. NIST PQC algorithms. Preparing for quantum computing threats.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+AUTOSAR Classic Basic Software stack
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/2b-MWLayer/Storage/BB_Eclipse_S-CORE_persistency.md
+++ b/BB-SC/2b-MWLayer/Storage/BB_Eclipse_S-CORE_persistency.md
@@ -15,6 +15,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Source code at https://github.com/eclipse-score/persistency. The crate provides a simple Key-Value Store API in Rust — add it as a dependency and use `put`/`get` operations to persist application state. Data is serialized with TinyJSON and validated with Adler32 checksums for integrity. No external dependencies beyond `std` are required, making it suitable for constrained embedded environments. Built with Bazel as part of the S-CORE project.
 
 ## Known Implementation
 
@@ -30,6 +31,7 @@ This crate provides a Key-Value-Store using TinyJSON to persist the data. It use
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Automotive middleware on HPC ECUs needs a lightweight, reliable persistence mechanism for configuration and runtime state that avoids the overhead and complexity of general-purpose databases. This Key-Value Store is designed with minimal dependencies (Rust std only) and built-in data integrity validation, making it suitable for safety-relevant embedded systems where simplicity and auditability are critical.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/2b-MWLayer/Storage/BB_Eclipse_S-CORE_persistency.md
+++ b/BB-SC/2b-MWLayer/Storage/BB_Eclipse_S-CORE_persistency.md
@@ -46,18 +46,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Rust toolchain (std only), Bazel build system
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Any platform with Rust std library support.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
-TBD
+Data integrity validation via Adler32. Minimal dependencies (std-only).
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
-TBD
+None. Standalone Rust crate.
 
 ## Vehicle API Relevant
 <!-- If “Yes exists” – where – e.g. COVESA VSS 

--- a/BB-SC/3-AppLayer/API/BB_Automotive_API_Framework.md
+++ b/BB-SC/3-AppLayer/API/BB_Automotive_API_Framework.md
@@ -14,6 +14,7 @@ AppLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Project repository at https://github.com/eclipse-autoapiframework. The framework provides a model-driven approach to define stable application-facing APIs that abstract the underlying E/E architecture. Developers use the configuration model to specify API variants for different vehicle configurations. The framework generates code stubs and adapters, decoupling application logic from platform-specific middleware. See the [Eclipse project page](https://projects.eclipse.org/projects/automotive.autoapiframework) for status and documentation.
 
 
 ## Known Implementation
@@ -27,6 +28,7 @@ The Eclipse Automotive API Framework provides a stable application-facing interf
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Automotive applications today are tightly coupled to OEM-specific middleware APIs, making portability and multi-supplier development costly. The Automotive API Framework provides a standardized, stable application interface that abstracts away E/E architecture differences, enabling suppliers to develop once and deploy across multiple vehicle platforms without proprietary lock-in.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/BB-SC/3-AppLayer/API/BB_Automotive_API_Framework.md
+++ b/BB-SC/3-AppLayer/API/BB_Automotive_API_Framework.md
@@ -44,16 +44,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Interface definition language tooling (project-specific)
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Platform-agnostic API specification with runtime components.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+Stable API surface across vehicle variants and E/E architectures.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
+FC Communication (underlying transport layer)
 
 
 ## Vehicle API Relevant

--- a/BB-SC/3-AppLayer/API/BB_Open_Vehicle_API.md
+++ b/BB-SC/3-AppLayer/API/BB_Open_Vehicle_API.md
@@ -14,6 +14,7 @@ AppLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Project repository at https://github.com/eclipse-openvehicle-api. Documentation available at https://eclipse.dev/openvehicle-api/. The API uses a component-based approach where vehicle functions are implemented against an abstraction layer. Tools automate code generation from signal/event definitions, reducing manual coding. Supports both SIL and HIL testing workflows. Developers define function interfaces once and deploy across different vehicle platforms.
 
 
 ## Known Implementation
@@ -37,6 +38,7 @@ The Eclipse Open Vehicle API contains tools and a runtime to create a vehicle ab
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Migrating signal-based ECU functions to HPCs and enabling a multi-vendor app ecosystem requires a standardized vehicle abstraction interface. Open Vehicle API provides vehicle-independent function interfaces with automated code generation, enabling OEMs and suppliers to develop portable, reusable vehicle functions that work across different E/E architectures and support both safety-critical (ADAS/chassis) and comfort domains.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/S-BB/2b-MWLayer/BB_Common_Vehicle_Capabilities.md
+++ b/S-BB/2b-MWLayer/BB_Common_Vehicle_Capabilities.md
@@ -13,7 +13,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Use the Common Vehicle Capabilities catalog to identify standardized, technology-neutral vehicle capability definitions and their interfaces. This serves as a reference for application developers who need to discover what commodity functions a vehicle platform exposes. See https://covesa.global/project/common-vehicle-capabilities/ for the current catalog.
 
 ## Known Implementation
 https://covesa.global/project/common-vehicle-capabilities/
@@ -26,6 +26,7 @@ Enumerate and define common (commodity) vehicle capabilities and their interface
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Application developers need a common, vendor-neutral enumeration of vehicle capabilities to write portable software. Without standardized capability definitions, each OEM platform requires custom integration, hindering ecosystem scalability.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/S-BB/2b-MWLayer/BB_Data_Architecture_Terminology.md
+++ b/S-BB/2b-MWLayer/BB_Data_Architecture_Terminology.md
@@ -13,7 +13,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Use this as a reference for common architectural terminology and patterns when designing vehicle data architectures. It provides definitions and proof-of-concept implementations that align with COVESA specifications. See https://covesa.global/project/data-architecture-terminology/ for the current terminology set.
 
 ## Known Implementation
 https://covesa.global/project/data-architecture-terminology/
@@ -26,6 +26,7 @@ Definition of reusable common architectural terminology and patterns realized wi
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+The SDV ecosystem lacks consistent terminology for data architecture concepts, leading to miscommunication across organizations. A shared vocabulary with reference implementations drives understanding and adoption of COVESA data specifications.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/S-BB/2b-MWLayer/BB_EV_Charging_Event_Data_Aggregation.md
+++ b/S-BB/2b-MWLayer/BB_EV_Charging_Event_Data_Aggregation.md
@@ -13,7 +13,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+This building block defines standards for collecting and aggregating EV charging event data across OEMs. It provides data schemas and interfaces for sharing charging session telemetry (success/failure rates, connector types, power levels) to improve charging infrastructure analytics. See https://covesa.global/project/ev-charging-event-data-aggregation/ for specifications and participation details.
 
 ## Known Implementation
 https://covesa.global/project/ev-charging-event-data-aggregation/
@@ -26,6 +26,7 @@ Addressing standards for EV charging experiences by levaraging shared big data.
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+EV charging reliability is a key barrier to adoption. By standardizing how charging event data is collected and shared across OEMs, the industry can collaboratively identify problematic charging stations, improve route planning with reliable charger information, and drive infrastructure improvements based on aggregated big data insights.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/S-BB/2b-MWLayer/BB_HIM.md
+++ b/S-BB/2b-MWLayer/BB_HIM.md
@@ -13,7 +13,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Define hierarchical domain models using the HIM format. Use the tooling at https://github.com/COVESA/hierarchical_information_model to create, validate, and transform domain-specific signal trees (e.g., extending VSS with custom branches).
 
 ## Known Implementation
 https://github.com/COVESA/hierarchical_information_model
@@ -26,6 +26,7 @@ The HIM aims to provide a format for expressing a hierarchical representation of
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Vehicle data models (like VSS) need a formal, extensible format for expressing hierarchical signal structures that can be shared, validated, and transformed across different tools and organizations.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/S-BB/2b-MWLayer/BB_In_Car_Wallet_Payments_and_Orchestration.md
+++ b/S-BB/2b-MWLayer/BB_In_Car_Wallet_Payments_and_Orchestration.md
@@ -13,7 +13,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+This building block provides a framework for integrating payment services into the vehicle. It defines APIs and orchestration flows for in-car wallet management, enabling services such as fuel/charging payments, parking, tolling, and drive-through purchases directly from the vehicle HMI. See https://covesa.global/project/in-car-wallet-payments-orchestration/ for specifications.
 
 ## Known Implementation
 https://covesa.global/project/in-car-wallet-payments-orchestration/
@@ -26,6 +26,7 @@ Secure and convenient payment system framework for vehicles.
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Vehicles are becoming commerce platforms, but payment integration is fragmented across OEMs and service providers. A standardized in-car wallet and payment orchestration framework enables secure, convenient transactions from the vehicle while reducing integration effort for third-party payment providers and service ecosystems.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/S-BB/2b-MWLayer/BB_PilotAutoReferenceDesign.md
+++ b/S-BB/2b-MWLayer/BB_PilotAutoReferenceDesign.md
@@ -13,7 +13,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+The Pilot.Auto Reference Design provides use-case-driven system architecture documentation for autonomous driving. Developers can copy and customize the reference design to accelerate their own AD system development. See https://docs.pilot.auto/en/reference-design/ for the full reference design documentation and use case specifications.
 
 ## Known Implementation
 https://docs.pilot.auto/en/reference-design/
@@ -26,6 +26,7 @@ Reference Design of Pilot.Auto is a reference design for the autonomous driving 
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Developing autonomous driving systems from scratch requires significant design effort and carries risk of architectural mistakes. A publicly available, use-case-driven reference design allows teams to start from a proven system concept, visualize system operations concretely, and customize it to their specific needs rather than designing from zero.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/S-BB/2b-MWLayer/BB_Private_Cross_OEM_Joint_Compute_for_EV_Charging.md
+++ b/S-BB/2b-MWLayer/BB_Private_Cross_OEM_Joint_Compute_for_EV_Charging.md
@@ -13,7 +13,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+This building block enables privacy-preserving joint computation across OEMs for EV charging analytics. OEMs contribute anonymized charging data to shared compute infrastructure without exposing proprietary fleet information. See https://covesa.global/project/private-cross-oem-joint-compute-for-ev-charging/ for architecture and participation guidelines.
 
 ## Known Implementation
 https://covesa.global/project/private-cross-oem-joint-compute-for-ev-charging/
@@ -26,6 +26,7 @@ Publicly available, shared EV charging infrastructure is foundational for EV ado
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Improving EV charging infrastructure requires data sharing across OEMs, but competitive and privacy concerns prevent open data exchange. Privacy-preserving joint compute allows multiple OEMs to collaboratively analyze charging patterns, station reliability, and route optimization without exposing individual fleet data or customer information.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/S-BB/2b-MWLayer/BB_Unified_Push_Notification.md
+++ b/S-BB/2b-MWLayer/BB_Unified_Push_Notification.md
@@ -13,7 +13,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+This building block standardizes how third-party services deliver push notifications to vehicles. It defines notification delivery protocols, priority levels, and HMI integration patterns so that app developers can send timely alerts (e.g., charging complete, parking expiry, service reminders) to the vehicle user experience. See https://covesa.global/project/unified-push-notifications/ for the specification.
 
 ## Known Implementation
 https://covesa.global/project/unified-push-notifications/
@@ -26,6 +26,7 @@ Standardize 3rd party push notifications for automotive user experiences.
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Unlike mobile platforms with established push notification services (APNs, FCM), the automotive domain lacks a standardized mechanism for third-party apps to deliver notifications to vehicle infotainment systems. A unified push notification standard enables consistent user experiences across OEMs and reduces fragmentation for service providers.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/S-BB/2b-MWLayer/BB_VSS.md
+++ b/S-BB/2b-MWLayer/BB_VSS.md
@@ -48,16 +48,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+VSS-tools (Python-based), YAML editing
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Any platform with Python 3. Output formats: JSON, CSV, Protobuf, DDS IDL, Franca, GraphQL.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+Protocol-agnostic signal taxonomy. Vendor-neutral.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
+None. Foundation specification used by KUKSA, VISS, and other BBs.
 
 
 ## Vehicle API Relevant

--- a/S-BB/2b-MWLayer/BB_VSS.md
+++ b/S-BB/2b-MWLayer/BB_VSS.md
@@ -13,7 +13,13 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Documentation: https://covesa.github.io/vehicle_signal_specification/
 
+VSS defines a tree of vehicle signals (e.g., `Vehicle.Speed`, `Vehicle.Cabin.Door.Row1.Left.IsOpen`) in `.vspec` YAML files. Use the VSS-tools (https://github.com/COVESA/vss-tools) to transform source `.vspec` files to other formats (JSON, CSV, Protobuf, DDS IDL, Franca, GraphQL, etc.).
+
+Releases with pre-built signal catalogs are available at: https://github.com/COVESA/vehicle_signal_specification/releases
+
+The community holds regular calls to discuss VSS evolution; see the project wiki for meeting coordinates.
 
 ## Known Implementation
 https://github.com/covesa/vehicle_signal_specification
@@ -26,6 +32,7 @@ The overall goal of the Vehicle Signal Specification (VSS) is to create a common
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Today, every OEM and supplier defines vehicle signals differently, leading to fragmented tooling and high integration costs. VSS provides a standardized, protocol-agnostic taxonomy of vehicle signals that enables interoperability across the entire SDV ecosystem. By establishing a common language for vehicle data, VSS allows applications, services, and tools from different vendors to work together without custom per-OEM adaptations. Significant contributions come from BMW, Volvo, Jaguar Land Rover, Bosch, and Geotab.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/S-BB/2b-MWLayer/BB_eSyncAlliance.md
+++ b/S-BB/2b-MWLayer/BB_eSyncAlliance.md
@@ -13,7 +13,7 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Adopt the eSync platform specification for OTA update infrastructure. Integrate eSync-compliant client agents on vehicle ECUs and connect to eSync-compatible cloud backends. See https://esyncalliance.org/technology/ for the specification and member resources.
 
 ## Known Implementation
 https://esyncalliance.org/technology/
@@ -28,6 +28,7 @@ The Alliance is based around the eSync platform of cloud and embedded components
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Vehicles require a standardized, secure OTA update and data gathering solution that is interoperable across OEMs and suppliers, meeting UNECE 156 requirements for software update management systems.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/S-BB/2b-MWLayer/Communication/BB_VISS.md
+++ b/S-BB/2b-MWLayer/Communication/BB_VISS.md
@@ -48,16 +48,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+Web technologies (HTTP, WebSocket). ReSpec for specification editing.
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Reference implementation (vissr) requires Go. Server exposes HTTP/WebSocket endpoints.
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+Standardized API for VSS access. AUTOSAR Adaptive R24-11 compliant.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
+S-BB/VSS (Vehicle Signal Specification data model)
 
 
 ## Vehicle API Relevant

--- a/S-BB/2b-MWLayer/Communication/BB_VISS.md
+++ b/S-BB/2b-MWLayer/Communication/BB_VISS.md
@@ -14,7 +14,12 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
+Specification: https://github.com/COVESA/vehicle-information-service-specification
+Reference Implementation: https://github.com/COVESA/vissr
 
+VISS provides HTTP/WebSocket APIs for accessing VSS data with operations: get, set, subscribe, unsubscribe. The specification consists of Core, Transport, and Payload Encoding documents. Current version: VISS v3.1.
+
+VISS is referenced by AUTOSAR Adaptive R24-11 (Automotive API Gateway specification). Working group meets biweekly; schedule at https://wiki.covesa.global/
 
 ## Known Implementation
 https://github.com/COVESA/vehicle-information-service-specification
@@ -27,6 +32,7 @@ Vehicle Information Service Specification (VISS) is an API for accessing the COV
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Applications need a standardized, transport-agnostic API to access vehicle signal data defined by VSS. VISS provides this interface layer, enabling uniform access to the vehicle signal tree regardless of the underlying implementation. Its adoption by AUTOSAR Adaptive (Automotive API Gateway) demonstrates industry consensus. VISS supports the EU Data Act compliance requirements for standardized vehicle data access.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/S-BB/3-AppLayer/BB_LF_EVerest.md
+++ b/S-BB/3-AppLayer/BB_LF_EVerest.md
@@ -46,16 +46,20 @@ BB is a composition of other BBs -->
 
 ## What is needed to Design and Implement
 <!-- e.g. we expect to have a certain HW capability and or SW environment or Tool support, or a documentation, or an extra audit, or Test, or Compiler, or Prog. Language, … -->
+C++, Python, MQTT knowledge. Modular plugin architecture.
 
 ## What is needed to build and run
 <!-- e.g. we expect to have a certain HW capability, or Runtime Environment, or Pre-configuration, or Code-signing, or Test, … -->
+Linux. MQTT broker (Mosquitto). EV charging hardware interfaces (OCPP, ISO 15118).
 
 ## Non-Functional Requirements
 <!-- With respect to Safety, Security, Realtime, … -->
+Modular, interoperable. Supports ISO 15118 (Plug & Charge). Production-ready.
 
 ## Dependencies to other Clusters
 <!-- Other clusters are needed. FC Security, FC Storage, …
 e.g. If FC Security : Security BBs are needed but you can choose for example crypto BB-SC from company A or crypto BB-SC from company B; several compositions may work -->
+MQTT broker, EV charging standards (OCPP 1.6/2.0, ISO 15118)
 
 
 ## Vehicle API Relevant

--- a/S-BB/3-AppLayer/BB_LF_EVerest.md
+++ b/S-BB/3-AppLayer/BB_LF_EVerest.md
@@ -13,7 +13,9 @@ MWLayer
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+Documentation: https://everest.github.io/nightly/  
+Source code: https://github.com/EVerest  
+EVerest provides a modular, MQTT-based framework for building complete EV charging stacks. Configure charging scenarios by composing interchangeable modules (energy management, ISO 15118, OCPP, hardware drivers) and deploy on charging station controllers.
 
 ## Known Implementation
 https://everest.github.io/nightly/
@@ -28,6 +30,7 @@ The modular software architecture fosters customizability and lets you configure
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+The EV charging ecosystem requires interoperable, standards-compliant software stacks (ISO 15118, OCPP) that work across diverse hardware. EVerest provides an open, vendor-neutral framework that accelerates charging station development and ensures protocol compliance without proprietary lock-in.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system

--- a/S-BB/Generator/BB_Commercial_Vehicle_Information_Specifications.md
+++ b/S-BB/Generator/BB_Commercial_Vehicle_Information_Specifications.md
@@ -13,7 +13,7 @@ Generator
 ## BB Usage
 <!-- Example on how to use BB or link to documentation. Should include code snippets, information about usage, 
 trainings, skills, examples and how-to's. -->
-
+CVIS provides signal and service catalogs for commercial vehicles using the HIM (Hierarchical Information Model) rule set. Integrators use the catalogs to generate code, documentation, or validation artifacts for truck/bus platforms. See https://github.com/COVESA/commercial-vehicle-information-specifications for the specification files and tooling.
 
 ## Known Implementation
 https://github.com/COVESA/commercial-vehicle-information-specifications
@@ -26,6 +26,7 @@ The Commercial Vehicle Information Specifications (CVIS) project is aiming at de
 
 ## Rationale
 <!-- Explanation why we need the BB; what problem want to be solved -->
+Commercial vehicles have domain-specific signal and service needs that differ from passenger cars. CVIS provides standardized catalogs for trucks, buses, and other commercial vehicles, enabling interoperability and reducing per-OEM signal definition effort.
 
 ## Governance Applicable S-BB(s)
 <!-- Reference to e.g. UN/EU CRA Cyber Resilience Act; UNECE 156 - Software update and software update management system


### PR DESCRIPTION
Types of content added

- Documentation URLs pointing to official docs, getting started guides, API references
- Build/install commands (Docker, cargo, cmake, apt-get, etc.)
- Language bindings/platform support information
- Community links (Discord, Gitter, mailing lists)
- Rationale explaining the specific automotive/SDV problem each BB solves
- Replaced "TBD" placeholders with actual content (~10 files)

(This PR is supported by Claude)